### PR TITLE
test: resolve CodeQL cleanup warnings

### DIFF
--- a/tests/security/test_secure_memory.py
+++ b/tests/security/test_secure_memory.py
@@ -120,10 +120,15 @@ class TestSecureBytes:
 
     def test_exception_wipes_data(self):
         """Verify data is wiped even when exception occurs."""
-        secure = None
-        with pytest.raises(ValueError, match="test exception"):
-            with SecureBytes(b"classified") as secure:
+        secure = SecureBytes(b"classified")
+        try:
+            with secure:
                 raise ValueError("test exception")
+        except ValueError as exc:
+            assert str(exc) == "test exception"
+        else:
+            pytest.fail("SecureBytes context did not propagate the exception")
+
         with pytest.raises(AttributeError):
             _ = secure.data
 
@@ -176,10 +181,15 @@ class TestSecureString:
 
     def test_exception_wipes_string(self):
         """Verify string is wiped even when exception occurs."""
-        secure = None
-        with pytest.raises(ValueError, match="test exception"):
-            with SecureString("topsecret") as secure:
+        secure = SecureString("topsecret")
+        try:
+            with secure:
                 raise ValueError("test exception")
+        except ValueError as exc:
+            assert str(exc) == "test exception"
+        else:
+            pytest.fail("SecureString context did not propagate the exception")
+
         with pytest.raises(AttributeError):
             _ = secure.string
 

--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -612,11 +612,14 @@ class TestSecureTempFile:
     def test_create_secure_temp_file_cleanup_on_exception(self, tmp_path):
         """Test that temp file is cleaned up even if exception occurs."""
         temp_path = None
-        with pytest.raises(ValueError, match="Test error"):
+        try:
             with create_secure_temp_file(directory=tmp_path) as (fd, path):
                 temp_path = path
-                # Simulate an error
                 raise ValueError("Test error")
+        except ValueError as exc:
+            assert str(exc) == "Test error"
+        else:
+            pytest.fail("Secure temp file context did not propagate the exception")
 
         # File should still be cleaned up
         assert temp_path is not None


### PR DESCRIPTION
## Summary
- resolve CodeQL alerts #111-#116 in three exception-cleanup security tests
- replace inline unconditional raises under `pytest.raises` with explicit `try`/`except`/`else` control flow
- preserve assertions that secure memory and temporary files are cleaned after exceptions

## Why
CodeQL reported three paired `py/unreachable-statement` and `py/unused-local-variable` findings. The runtime tests were valid, but the nested unconditional raises made reachability and variable use ambiguous to static analysis. The revised structure makes exception propagation and post-exception cleanup explicit without changing production code.

## Scope
- `tests/security/test_secure_memory.py`
- `tests/security/test_security.py`

No production, dependency, workflow, or baseline changes.

## Verification
- focused affected tests: 3 passed
- full suite: 884 passed
- `uv run --locked ruff check src tests tools`
- `uv run --locked ruff format --check src tests tools`
- `uv run --locked mypy src`
- `uv run --locked detect-secrets scan --baseline .secrets.baseline`
- `uv run --locked python tools/check_sensitive_output.py`
- `uv run --locked pip-audit . --desc`: no known vulnerabilities
- `uv run --locked pre-commit run --all-files`

## Repository hygiene
- branched from merged `main`
- one focused Conventional Commit
- obsolete merged `codex/security-quality-alerts` branch removed locally and remotely
- active `codex/v2-module-skeleton` worktree and PR left untouched

## Note
`CONTRIBUTING.md` documents `mypy src tests`, but the repository currently has pre-existing untyped-test findings and CI checks `mypy src`. This PR follows the actual CI scope and does not mix an unrelated repository-wide test typing migration into the CodeQL fix.