### PR TITLE
test: make exception paths statically reachable

### DIFF
--- a/tests/security/test_secure_memory.py
+++ b/tests/security/test_secure_memory.py
@@ -11,6 +11,7 @@ Tests verify:
 """
 
 import array
+from unittest.mock import Mock
 
 import pytest
 
@@ -120,15 +121,13 @@ class TestSecureBytes:
 
     def test_exception_wipes_data(self):
         """Verify data is wiped even when exception occurs."""
+        trigger_error = Mock(side_effect=ValueError("test exception"))
         secure = SecureBytes(b"classified")
-        try:
+        with pytest.raises(ValueError, match="test exception"):
             with secure:
-                raise ValueError("test exception")
-        except ValueError as exc:
-            assert str(exc) == "test exception"
-        else:
-            pytest.fail("SecureBytes context did not propagate the exception")
+                trigger_error()
 
+        trigger_error.assert_called_once_with()
         with pytest.raises(AttributeError):
             _ = secure.data
 
@@ -181,15 +180,13 @@ class TestSecureString:
 
     def test_exception_wipes_string(self):
         """Verify string is wiped even when exception occurs."""
+        trigger_error = Mock(side_effect=ValueError("test exception"))
         secure = SecureString("topsecret")
-        try:
+        with pytest.raises(ValueError, match="test exception"):
             with secure:
-                raise ValueError("test exception")
-        except ValueError as exc:
-            assert str(exc) == "test exception"
-        else:
-            pytest.fail("SecureString context did not propagate the exception")
+                trigger_error()
 
+        trigger_error.assert_called_once_with()
         with pytest.raises(AttributeError):
             _ = secure.string
 

--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -5,7 +5,7 @@ Tests for security utilities (filename sanitization, path validation, symlink de
 import os
 from contextlib import suppress
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -611,17 +611,15 @@ class TestSecureTempFile:
 
     def test_create_secure_temp_file_cleanup_on_exception(self, tmp_path):
         """Test that temp file is cleaned up even if exception occurs."""
+        trigger_error = Mock(side_effect=ValueError("Test error"))
         temp_path = None
-        try:
+        with pytest.raises(ValueError, match="Test error"):
             with create_secure_temp_file(directory=tmp_path) as (fd, path):
                 temp_path = path
-                raise ValueError("Test error")
-        except ValueError as exc:
-            assert str(exc) == "Test error"
-        else:
-            pytest.fail("Secure temp file context did not propagate the exception")
+                trigger_error()
 
         # File should still be cleaned up
+        trigger_error.assert_called_once_with()
         assert temp_path is not None
         assert not os.path.exists(temp_path)
 


### PR DESCRIPTION
## Summary
- resolve post-merge CodeQL alerts #117-#119
- trigger expected test exceptions through `Mock(side_effect=...)` callbacks
- retain `pytest.raises` matching and all secure-memory/temp-file cleanup assertions

## Root cause
PR #44 fixed alerts #111-#116, but CodeQL correctly continued to identify the `else: pytest.fail(...)` branches as unreachable because each corresponding `try` block contained an unconditional inline raise. Moving the deterministic test exception behind a mock callback preserves runtime behavior without placing a statically provable no-return statement in the outer test control-flow graph.

## Scope
- `tests/security/test_secure_memory.py`
- `tests/security/test_security.py`

No production, dependency, workflow, or secret-baseline changes.

## Verification
- focused affected tests: 3 passed
- full suite: 884 passed
- Ruff lint and format checks passed
- `mypy src` passed
- detect-secrets passed
- sensitive-output guard passed
- pip-audit: no known vulnerabilities
- all pre-commit hooks passed

## Repository hygiene
- one focused Conventional Commit from current `main`
- active v2 branch/worktree untouched
- PR #44 branch and temporary worktree were deleted immediately after merge
- this branch and temporary worktree will be removed immediately after merge and successful default-branch CodeQL verification