### PR TITLE
ci: fix Codecov files input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,6 @@ jobs:
       if: matrix.python-version == '3.14'
       continue-on-error: true
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
## Summary
- replace obsolete Codecov v7 input `file` with supported input `files`
- remove the non-failing `Unexpected input(s) 'file'` annotation from Python 3.14 CI coverage uploads

## Scope
- `.github/workflows/ci.yml`

No source, test, dependency, or security-baseline changes.

## Verification
- all pre-commit hooks passed
- YAML validation passed
- PR CI will verify the Codecov action accepts the corrected input

## Repository hygiene
- one-line change
- one focused Conventional Commit from current `main`
- active v2 branch/worktree untouched
- branch and temporary worktree will be deleted immediately after merge