### PR TITLE
chore(docker,ci): pin base image digest, lock builder deps, add actionlint + dependency-review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,26 @@ jobs:
         tests/unit/test_v2_output_safety.py
         tests/unit/test_v2_keyfile.py
         -n 0
+
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: actionlint
+      uses: reviewdog/action-actionlint@d290e336d5a743810aef4404f757dc862276d2ae # v1.73.4
+      with:
+        fail_level: error
+
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Dependency review
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+      with:
+        fail-on-severity: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@
   comment now states explicitly why this is safe today (pinned `pynacl`
   version, `AttributeError`-tolerant fallback, direct test coverage of both
   code paths) and what the durable fix would be.
+- **Docker supply-chain hardening.** `Dockerfile`'s two `FROM python:3.14-alpine`
+  stages are now pinned to the exact multi-arch index digest
+  (`sha256:c6ead215...`) instead of a mutable tag; the builder stage's
+  `pip install build cryptography wcwidth pyperclip` is now pinned to the
+  exact versions `pyproject.toml`/`uv.lock` require, so the wheel this
+  stage builds is metadata-consistent with the hash-locked wheel `make
+  build` produces for the PyPI release. The `HEALTHCHECK` now runs
+  `ssc --version` (a real check of the installed console-script entry
+  point) instead of a `python -c "import sys; sys.exit(0)"` that always
+  passed regardless of whether the image was actually broken.
+- **CI: added `actionlint`** (workflow-file static analysis) as its own
+  job, and **`dependency-review-action`** (fails a PR that introduces a
+  high-severity-vulnerable dependency) gated on `pull_request` events.
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.14-alpine AS builder
+# python:3.14-alpine (3.14.7-alpine3.24, multi-arch index digest)
+FROM python:3.14-alpine@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -18,17 +19,25 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 COPY pyproject.toml README.md LICENSE ./
 
+# Pinned to the same exact versions pyproject.toml/uv.lock require, so the
+# wheel this stage builds is metadata-consistent with the hash-locked wheel
+# `make build` produces for the PyPI release (see Makefile's `build` target).
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cargo/registry \
     pip install --upgrade pip \
-    && pip install build cryptography wcwidth pyperclip
+    && pip install \
+    build==1.3.0 \
+    cryptography==50.0.1 \
+    wcwidth==0.8.3 \
+    pyperclip==1.11.0
 
 COPY src/ ./src/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m build --wheel --outdir /build/wheels
 
-FROM python:3.14-alpine
+# python:3.14-alpine (3.14.7-alpine3.24, multi-arch index digest)
+FROM python:3.14-alpine@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc
 
 ARG SSC_VERSION=dev
 
@@ -56,8 +65,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 USER cipheruser
 WORKDIR /data
 
+# Exercises the actual installed console_script entry point end to end
+# (import + argparse + version resolution), not just "is Python alive".
 HEALTHCHECK --interval=10s --timeout=2s --start-period=3s --retries=2 \
-    CMD python -c "import sys; sys.exit(0)"
+    CMD ssc --version || exit 1
 
 ENTRYPOINT ["ssc"]
 CMD ["start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - /tmp:rw,noexec,nosuid,nodev,size=100m
 
     healthcheck:
-      test: ["CMD", "python", "-c", "import sys; sys.exit(0)"]
+      test: ["CMD", "ssc", "--version"]
       interval: 10s
       timeout: 2s
       retries: 2


### PR DESCRIPTION
## Summary
Post-v2 hardening review, repository-maturity items (PR-B of the finding-matrix backlog):

- **Docker base image**: both `FROM python:3.14-alpine` stages now pin the exact multi-arch index digest (`sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc`, currently `3.14.7-alpine3.24`) instead of a mutable tag. Dependabot's existing `docker` ecosystem entry (monthly) will keep the pin current, the same pattern this repo already uses for SHA-pinned GitHub Actions.
- **Builder-stage dependency pinning**: `pip install build cryptography wcwidth pyperclip` was completely unpinned; now pinned to the exact versions `pyproject.toml`/`uv.lock` require, so the wheel this stage builds is metadata-consistent with the hash-locked wheel `make build` produces for the PyPI release.
- **Healthcheck**: `python -c "import sys; sys.exit(0)"` always passed regardless of whether the image was broken. Now runs `ssc --version`, which actually exercises the installed console-script entry point.
- **CI**: added `actionlint` as its own job (workflow-file static analysis) and `dependency-review-action` gated on `pull_request` (fails a PR introducing a high-severity-vulnerable dependency).

## Test plan
- [x] `docker build --check -f Dockerfile .` — clean, no warnings
- [x] Full local build succeeds; `docker run --rm <image> --version` prints `secure-string-cipher 2.0.0` with exit 0
- [x] `actionlint v1.7.7` run locally against every file in `.github/workflows/` (including this change) — zero findings
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)