### PR TITLE
refactor(security): simplify fallback memory wipe, document PyNaCl private-FFI risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Secure-memory fallback wiping simplified to a single zero-fill pass.**
+  When libsodium's `sodium_memzero` isn't available, `secure_wipe`'s
+  fallback previously did 3 passes of random data followed by a zero-fill.
+  RAM has no magnetic remanence for extra random passes to defeat (that's
+  a spinning-disk-forensics concern), and CPython has no dead-store-elimination
+  optimizer that would silently drop a real buffer-protocol write the way a
+  C compiler can drop a provably-dead local `memset` — so the random passes
+  added runtime cost without adding any real erasure guarantee beyond what
+  the final zero-fill already provided on its own. Functional behavior
+  (the buffer ends up zeroed) is unchanged.
+- **Documented the PyNaCl private-FFI reliance as accepted technical debt**,
+  inline in `secure_memory.py`: `nacl._sodium` is not a public API, and the
+  comment now states explicitly why this is safe today (pinned `pynacl`
+  version, `AttributeError`-tolerant fallback, direct test coverage of both
+  code paths) and what the durable fix would be.
+
 ## [2.0.0] - 2026-09-11
 
 This is a major version for one specific reason: **`ssc vault backups`/

--- a/src/secure_string_cipher/secure_memory.py
+++ b/src/secure_string_cipher/secure_memory.py
@@ -13,11 +13,22 @@ Limitations (even with libsodium):
 from __future__ import annotations
 
 import array
-import secrets
 from types import TracebackType
 from typing import TYPE_CHECKING
 
-# Try to use libsodium for secure memory operations via PyNaCl's internal FFI
+# Try to use libsodium for secure memory operations via PyNaCl's internal FFI.
+#
+# `nacl._sodium` is PyNaCl's private cffi module, not a documented public
+# API — it has no compatibility guarantee across PyNaCl releases. This is
+# accepted, known technical debt, not an oversight: `pynacl` is exact-pinned
+# in pyproject.toml, `_sodium_memzero`'s own try/except below treats any
+# AttributeError from a shape change as "fall back to the Python path"
+# rather than crashing, and `tests/security/test_secure_memory.py` exercises
+# both the libsodium and fallback code paths directly, so an incompatible
+# PyNaCl upgrade fails a test rather than silently losing sodium_memzero.
+# The durable fix is a supported public API or a small maintained native
+# extension; short of that, this import is re-verified on every PyNaCl
+# version bump rather than assumed stable.
 try:
     from nacl import bindings as _sodium_bindings
     from nacl._sodium import ffi as _ffi
@@ -87,7 +98,7 @@ def secure_wipe(data: bytes | bytearray | memoryview | array.array) -> None:
     Securely wipe sensitive data from memory.
 
     Uses libsodium's sodium_memzero() when available (guaranteed not optimized away).
-    Falls back to multi-pass random overwrite + zero fill otherwise.
+    Falls back to a single zero-fill pass otherwise.
 
     Args:
         data: Mutable buffer (bytearray, memoryview, or array.array).
@@ -120,20 +131,20 @@ def _fallback_wipe(data: bytearray | memoryview | array.array) -> None:
     """
     Best-effort Python memory wiping.
 
-    Performs 3 passes of random data followed by zero fill.
-    This may be optimized away by the compiler/interpreter.
+    A single zero-fill pass, matching what sodium_memzero() itself does.
+    RAM has no magnetic remanence for multiple random passes to defeat (that
+    concern is specific to spinning-disk forensics), and CPython has no
+    dead-store-elimination optimizer that would silently drop a real
+    buffer-protocol write the way a C compiler can drop a provably-dead
+    local `memset` — so the extra random passes a prior version of this
+    function performed added runtime cost without adding any real erasure
+    guarantee beyond what the final zero-fill already provides on its own.
     """
     byte_view = _writable_byte_view(data)
     try:
-        # Bound temporary allocations while still operating on every byte of
-        # multi-byte array and memoryview elements.
-        for _ in range(3):
-            for start in range(0, byte_view.nbytes, _FALLBACK_WIPE_CHUNK_SIZE):
-                chunk_length = min(_FALLBACK_WIPE_CHUNK_SIZE, byte_view.nbytes - start)
-                byte_view[start : start + chunk_length] = secrets.token_bytes(
-                    chunk_length
-                )
-
+        # Bounded per-chunk allocation, not a single `bytes(nbytes)`, so
+        # wiping a very large buffer does not itself require allocating an
+        # equally large temporary zero buffer.
         for start in range(0, byte_view.nbytes, _FALLBACK_WIPE_CHUNK_SIZE):
             chunk_length = min(_FALLBACK_WIPE_CHUNK_SIZE, byte_view.nbytes - start)
             byte_view[start : start + chunk_length] = bytes(chunk_length)

--- a/tests/security/test_secure_memory.py
+++ b/tests/security/test_secure_memory.py
@@ -2,7 +2,7 @@
 Tests for secure memory operations.
 
 Tests verify:
-- Memory wiping with multiple overwrite passes
+- Memory wiping via the fallback single zero-fill pass
 - Context manager semantics and automatic cleanup
 - Exception safety (data wiped even on errors)
 - Constant-time comparison resistance
@@ -487,28 +487,28 @@ class TestLibsodiumIntegration:
 
         assert memoryview(data).cast("B").tobytes() == bytes(data.itemsize * len(data))
 
-    def test_fallback_wipe_bounds_random_allocations(self, monkeypatch):
-        """Verify fallback random passes allocate at most one bounded chunk."""
+    def test_fallback_wipe_zeros_in_bounded_chunks(self, monkeypatch):
+        """Verify the fallback zero-fills in at most one bounded chunk at a time."""
         from secure_string_cipher.secure_memory import _fallback_wipe
 
         chunk_size = secure_memory_module._FALLBACK_WIPE_CHUNK_SIZE
         data = bytearray(b"x" * (2 * chunk_size + 17))
         requested_lengths = []
 
-        def deterministic_token_bytes(length):
+        real_bytes = bytes
+
+        def recording_bytes(length):
             requested_lengths.append(length)
-            return b"\xa5" * length
+            return real_bytes(length)
 
         monkeypatch.setattr(
-            secure_memory_module.secrets,
-            "token_bytes",
-            deterministic_token_bytes,
+            secure_memory_module, "bytes", recording_bytes, raising=False
         )
 
         _fallback_wipe(data)
 
-        assert data == bytes(len(data))
-        assert requested_lengths == [chunk_size, chunk_size, 17] * 3
+        assert data == real_bytes(len(data))
+        assert requested_lengths == [chunk_size, chunk_size, 17]
 
     @pytest.mark.skipif(
         not __import__(


### PR DESCRIPTION
## Summary
Post-v2 hardening review, secure-memory items (PR-A continuation):

- `secure_wipe()`'s Python fallback (used only when libsodium's `sodium_memzero` is unavailable) did 3 passes of random overwrite + a final zero-fill. That's a holdover from disk-forensics practice — RAM has no magnetic remanence for extra random passes to defeat, and CPython has no dead-store-elimination optimizer that would drop a real buffer-protocol write the way a C compiler can drop a provably-dead local `memset`. Simplified to a single zero-fill pass, still done in bounded chunks. The functional outcome (buffer ends up zeroed) is unchanged; only the discarded intermediate random values are gone, and nothing observed those anyway.
- Documented the reliance on `nacl._sodium` (PyNaCl's private FFI module) inline: why it's an accepted risk today (`pynacl` is exact-pinned in `pyproject.toml`, `_sodium_memzero`'s own `except` clause already tolerates `AttributeError` from an API shape change rather than crashing, both the libsodium and fallback paths have direct test coverage) and what the durable fix would look like.
- `THREAT_MODEL.md`'s §5.3 (Memory Zeroization) was checked and is already precise — it already discloses that the V2 DEK path copies to an immutable `bytes` before use, which `SecureBytes`' zeroing can't reach. No changes needed there.

## Test plan
- [x] Rewrote `test_fallback_wipe_bounds_random_allocations` → `test_fallback_wipe_zeros_in_bounded_chunks` to assert the new single-pass chunking instead of the old 3x pattern.
- [x] `tests/security/` + `tests/unit/`: 1466 passed.
- [x] `ruff check` / `ruff format --check` / `mypy src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)