### PR TITLE
feat(v2): extract a reusable application layer for credentials and key policy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 452
+        "line_number": 453
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T20:57:08Z"
+  "generated_at": "2026-09-12T21:12:58Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 440
+        "line_number": 452
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T10:44:54Z"
+  "generated_at": "2026-09-12T20:57:08Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`secure_string_cipher.v2.app` — a reusable application layer for v2
+  credentials and managed-key policy.** Key resolution, key-status policy,
+  header→requirement mapping, armoured-header parsing and credential
+  assembly previously lived in `cli_args.py` as private helpers that called
+  `sys.exit()` and `getpass()` directly, so no other interface could use
+  them: a second surface calling the key-status check would have terminated
+  the process rather than reporting an error. The new module performs no
+  interactive input and never exits; it raises typed errors under a common
+  `V2AppError` base. Obtaining a password stays with the caller, since where
+  a password comes from is an interface concern. `cli_args.py` is now an
+  adapter over it with identical behaviour. Its stability tier is still to
+  be decided — the module is importable but not yet re-exported.
+
 ### Fixed
 
 - **Stale "V2 not yet released" banners.** `docs/API.md`'s "V2 Encryption"

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -57,6 +57,19 @@ from .rate_limiter import PersistentRateLimiter, RateLimitError
 from .security import SecurityError
 from .timing_safe import check_password_strength
 from .utils import colorize, secure_overwrite
+from .v2.app import (
+    KeyFileNotFound,
+    KeyFileUnreadable,
+    KeyResolver,
+    KeyStatusPolicy,
+    KeyStatusRejected,
+    MalformedContainer,
+    NoUsableGrant,
+    VaultUnlockFailed,
+    build_credential,
+    header_from_armour,
+    required_credential,
+)
 from .v2.decrypt import decrypt_v2_file, decrypt_v2_text
 from .v2.encrypt import (
     CombinedCredential,
@@ -66,8 +79,7 @@ from .v2.encrypt import (
     encrypt_v2_file,
     encrypt_v2_text,
 )
-from .v2.key_identity import KeyStatus
-from .v2.keyfile import KeyFileData, load_keyfile
+from .v2.keyfile import KeyFileData
 from .v2.keywrap import KeyWrapError
 from .v2.vault_lock import VaultBusyError
 from .v2.vault_service import (
@@ -862,37 +874,25 @@ def _get_v1_password(args: argparse.Namespace) -> str:
 
 
 def _resolve_v2_key_source(key_ref: str) -> KeyFileData:
-    """Resolve a V2 key reference to validated keyfile data.
+    """CLI adapter over ``v2.app.KeyResolver``.
 
-    ``key_ref`` is either a path to a ``.ssckey`` file or a fingerprint/key-id
-    registered under ``~/.ssc/keys/``. Shared by encryption (``key:X`` sources)
-    and decryption (``--key-file`` or header grant fingerprints) so both sides
-    use one resolution model. ``load_keyfile`` always receives a ``Path``.
+    The resolution logic itself lives in the application layer so the
+    interactive menu and library callers can use it; this wrapper only turns
+    its typed errors into CLI exits.
     """
-    candidate = Path(key_ref).expanduser()
-    if candidate.suffix == ".ssckey" or candidate.is_file():
-        try:
-            return load_keyfile(candidate)
-        except Exception:
-            _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
-
-    keys_dir = Path.home() / ".ssc" / "keys"
-    if keys_dir.is_dir():
-        for child in sorted(keys_dir.iterdir()):
-            if child.suffix != ".ssckey":
-                continue
-            try:
-                key_data = load_keyfile(child)
-            except Exception:
-                continue
-            if key_ref in (key_data.fingerprint, key_data.key_id):
-                return key_data
-
-    _exit_error(
-        EXIT_FILE_ERROR,
-        "Key not found: provide a .ssckey path or a fingerprint/key-id "
-        "present in ~/.ssc/keys/.",
-    )
+    try:
+        return KeyResolver().resolve(key_ref)
+    except KeyFileUnreadable:
+        _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
+    except KeyFileNotFound as error:
+        # Hoisted out of the message expression so no exception name appears
+        # in the sink call itself (tools/check_sensitive_output.py).
+        keys_dir = error.keys_dir
+        _exit_error(
+            EXIT_FILE_ERROR,
+            "Key not found: provide a .ssckey path or a fingerprint/key-id "
+            f"present in {keys_dir}.",
+        )
 
 
 def _get_v2_password(args: argparse.Namespace) -> str:
@@ -919,105 +919,65 @@ def _enforce_v2_key_status(fingerprint: str) -> None:
     if not vault.vault_exists():
         return
     master = _prompt_master_password()
-    service = V2VaultService(vault)
     try:
-        records = service.list_keys(master)
-    except Exception:
+        KeyStatusPolicy(V2VaultService(vault)).check(
+            fingerprint, master_password=master
+        )
+    except KeyStatusRejected as error:
+        rejected_id, rejected_status = error.key_id, error.status.value
+        _exit_error(
+            EXIT_AUTH_ERROR,
+            f"Key '{rejected_id}' is {rejected_status} in this vault; "
+            "refusing to use it.",
+        )
+    except VaultUnlockFailed:
         _exit_error(EXIT_AUTH_ERROR, "Could not unlock vault to check key status.")
-    for record in records:
-        if record.fingerprint != fingerprint:
-            continue
-        if record.status == KeyStatus.REVOKED:
-            _exit_error(
-                EXIT_AUTH_ERROR,
-                f"Key '{record.id}' is revoked in this vault; refusing to use it.",
-            )
-        if record.status == KeyStatus.DESTROYED:
-            _exit_error(
-                EXIT_AUTH_ERROR,
-                f"Key '{record.id}' has been destroyed in this vault; refusing "
-                "to use it.",
-            )
-        return
 
 
 def _resolve_v2_credential_from_header(
     header: V2Header, args: argparse.Namespace
 ) -> V2Credential:
-    from .v2.envelope import GrantType
+    """CLI adapter: obtain whatever the header's grant requires.
 
-    has_password = any(g.type == GrantType.PASSWORD for g in header.access.grants)
-    has_key = any(g.type == GrantType.MANAGED_KEY for g in header.access.grants)
-    has_combined = any(
-        g.type == GrantType.COMBINED_PASSWORD_MANAGED_KEY for g in header.access.grants
-    )
+    Deciding *what* is required, and assembling the credential, live in
+    ``v2.app``. What remains here is the interface's own business: where a
+    password comes from, how ``--key-file`` overrides the grant's named key,
+    and how failures map to exit codes.
+    """
+    try:
+        requirement = required_credential(header)
+    except NoUsableGrant:
+        _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
 
     key_file_ref = getattr(args, "key_file", None)
-
-    if has_combined:
-        password = _get_v2_password(args)
-        grant = next(
-            g
-            for g in header.access.grants
-            if g.type == GrantType.COMBINED_PASSWORD_MANAGED_KEY
+    if key_file_ref and not requirement.needs_managed_key:
+        _exit_error(
+            EXIT_INPUT_ERROR,
+            "--key-file is only usable with V2 key-protected containers.",
         )
-        if not grant.key_fingerprint:
-            _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
-        key_data = _resolve_v2_key_source(key_file_ref or grant.key_fingerprint)
+
+    password = _get_v2_password(args) if requirement.needs_password else None
+
+    key_data = None
+    if requirement.needs_managed_key:
+        assert requirement.key_fingerprint is not None
+        key_data = _resolve_v2_key_source(key_file_ref or requirement.key_fingerprint)
         if getattr(args, "vault", None):
-            _enforce_v2_key_status(grant.key_fingerprint)
-        return CombinedCredential(
-            passphrase=password,
-            key_fingerprint=grant.key_fingerprint,
-            managed_secret=key_data.secret_bytes,
-        )
+            _enforce_v2_key_status(requirement.key_fingerprint)
 
-    if has_password:
-        if key_file_ref:
-            _exit_error(
-                EXIT_INPUT_ERROR,
-                "--key-file is only usable with V2 key-protected containers.",
-            )
-        password = _get_v2_password(args)
-        return PasswordCredential(passphrase=password)
-
-    if has_key:
-        grant = next(g for g in header.access.grants if g.type == GrantType.MANAGED_KEY)
-        if not grant.key_fingerprint:
-            _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
-        key_data = _resolve_v2_key_source(key_file_ref or grant.key_fingerprint)
-        if getattr(args, "vault", None):
-            _enforce_v2_key_status(grant.key_fingerprint)
-        return KeyCredential(
-            key_fingerprint=grant.key_fingerprint, managed_secret=key_data.secret_bytes
-        )
-
-    _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
+    return build_credential(requirement, password=password, key_data=key_data)
 
 
 def _cmd_decrypt_v2(
     args: argparse.Namespace, is_message: bool, rate_identifier: str = ""
 ) -> int:
-    import base64
-    import json
 
-    from .v2.header_parser import parse_header_stream, validate_v2_header
-    from .v2.message import unarmor_message
-    from .v2.vault_schema import _reject_duplicate_object_hook
+    from .v2.header_parser import parse_header_stream
 
     if is_message:
-        # Armored messages carry the header as raw canonical JSON (Base64),
-        # not the binary SSC2 framing parse_header_stream expects. Mirror
-        # decrypt_v2_text: unarmor, decode, then validate the JSON header.
         try:
-            parsed = unarmor_message(args.text)
-            raw_bytes = base64.b64decode(parsed.header_b64, validate=True)
-            header_dict = json.loads(
-                raw_bytes.decode("utf-8"),
-                object_pairs_hook=_reject_duplicate_object_hook,
-            )
-            header = validate_v2_header(header_dict, raw_bytes)
-        except Exception:
+            header = header_from_armour(args.text)
+        except MalformedContainer:
             _cli_limiter.record_attempt("decrypt_text", "", success=False)
             _audit_encryption(AuditEvent.DECRYPT_TEXT, False, error="decryption_failed")
             _exit_error(EXIT_AUTH_ERROR, _V2_DECRYPT_FAILURE_MESSAGE)

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -58,6 +58,7 @@ from .security import SecurityError
 from .timing_safe import check_password_strength
 from .utils import colorize, secure_overwrite
 from .v2.app import (
+    KeyDirectoryUnreadable,
     KeyFileNotFound,
     KeyFileUnreadable,
     KeyResolver,
@@ -884,6 +885,9 @@ def _resolve_v2_key_source(key_ref: str) -> KeyFileData:
         return KeyResolver().resolve(key_ref)
     except KeyFileUnreadable:
         _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
+    except KeyDirectoryUnreadable as error:
+        keys_dir = error.keys_dir
+        _exit_error(EXIT_FILE_ERROR, f"Could not search the keys directory: {keys_dir}")
     except KeyFileNotFound as error:
         # Hoisted out of the message expression so no exception name appears
         # in the sink call itself (tools/check_sensitive_output.py).

--- a/src/secure_string_cipher/v2/app.py
+++ b/src/secure_string_cipher/v2/app.py
@@ -1,0 +1,366 @@
+"""Reusable application logic for v2 credentials and managed-key policy.
+
+This layer exists so that more than one interface can perform v2
+encrypt/decrypt correctly. The same logic previously lived in
+``cli_args.py`` as private helpers that called ``sys.exit`` and ``getpass``
+directly, which made it unusable from anywhere else: a second surface
+calling the key-status check would have terminated the process instead of
+reporting an error, and would have blocked on a terminal prompt.
+
+Nothing here performs interactive input or exits the process. Callers supply
+credentials and receive either a value or a typed exception, and decide for
+themselves how to prompt, render and exit.
+
+Deliberately *not* included: obtaining a password. Where a password comes
+from — a prompt, a vault entry, a file, an environment variable — is an
+interface concern, so it stays with the caller. This module only says which
+credential an object requires and assembles one from parts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from secure_string_cipher.v2.encrypt import (
+    CombinedCredential,
+    KeyCredential,
+    PasswordCredential,
+    V2Credential,
+)
+from secure_string_cipher.v2.envelope import GrantType, V2Header
+from secure_string_cipher.v2.key_identity import KeyStatus
+from secure_string_cipher.v2.keyfile import KeyFileData, load_keyfile
+from secure_string_cipher.v2.vault_service import V2VaultService
+
+__all__ = [
+    "CredentialRequirement",
+    "GrantRequirement",
+    "KeyResolver",
+    "KeyStatusPolicy",
+    "KeyFileNotFound",
+    "KeyFileUnreadable",
+    "KeyStatusRejected",
+    "MalformedContainer",
+    "NoUsableGrant",
+    "V2AppError",
+    "VaultUnlockFailed",
+    "build_credential",
+    "default_keys_dir",
+    "header_from_armour",
+    "required_credential",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class V2AppError(Exception):
+    """Base class for a v2 application-layer failure."""
+
+
+class KeyFileNotFound(V2AppError):
+    """No `.ssckey` matched the supplied reference."""
+
+    def __init__(self, key_ref: str, keys_dir: Path):
+        self.key_ref = key_ref
+        self.keys_dir = keys_dir
+        super().__init__(
+            f"Key not found: provide a .ssckey path or a fingerprint/key-id "
+            f"present in {keys_dir}."
+        )
+
+
+class KeyFileUnreadable(V2AppError):
+    """A `.ssckey` was located but could not be loaded or validated."""
+
+    def __init__(self, path: Path, cause: BaseException):
+        self.path = path
+        self.cause = cause
+        super().__init__(f"Could not load key file: {path}")
+
+
+class KeyStatusRejected(V2AppError):
+    """The vault tracks this key and marks it unusable."""
+
+    def __init__(self, key_id: str, status: KeyStatus):
+        self.key_id = key_id
+        self.status = status
+        verb = (
+            "is revoked in" if status == KeyStatus.REVOKED else "has been destroyed in"
+        )
+        super().__init__(f"Key '{key_id}' {verb} this vault; refusing to use it.")
+
+
+class VaultUnlockFailed(V2AppError):
+    """The vault could not be opened to read key status."""
+
+    def __init__(self, cause: BaseException | None = None):
+        self.cause = cause
+        super().__init__("Could not unlock vault to check key status.")
+
+
+class NoUsableGrant(V2AppError):
+    """The header carries no grant this implementation can satisfy."""
+
+    def __init__(self) -> None:
+        super().__init__("No usable access grant found in V2 header.")
+
+
+class MalformedContainer(V2AppError):
+    """The input is not a well-formed v2 container."""
+
+    def __init__(self, cause: BaseException | None = None):
+        self.cause = cause
+        super().__init__("Not a valid V2 container.")
+
+
+# ---------------------------------------------------------------------------
+# What a container requires
+# ---------------------------------------------------------------------------
+
+
+class CredentialRequirement(Enum):
+    """The credential an object's single grant requires."""
+
+    PASSWORD = "password"  # pragma: allowlist secret - grant type name
+    MANAGED_KEY = "managed-key"
+    COMBINED = "combined-password-managed-key"
+
+
+@dataclass(frozen=True)
+class GrantRequirement:
+    """What a caller must supply to open a particular object.
+
+    `key_fingerprint` is the fingerprint the grant names, present whenever a
+    managed key is involved. A caller may resolve a different keyfile than
+    the named one (the CLI's `--key-file` does this), but the fingerprint
+    recorded in the grant is what the DEK was wrapped against.
+    """
+
+    requirement: CredentialRequirement
+    key_fingerprint: str | None = None
+
+    @property
+    def needs_password(self) -> bool:
+        return self.requirement in (
+            CredentialRequirement.PASSWORD,
+            CredentialRequirement.COMBINED,
+        )
+
+    @property
+    def needs_managed_key(self) -> bool:
+        return self.requirement in (
+            CredentialRequirement.MANAGED_KEY,
+            CredentialRequirement.COMBINED,
+        )
+
+
+def header_from_armour(armoured_text: str) -> V2Header:
+    """Extract and validate the protected header from an armoured message.
+
+    An armoured message carries its header as Base64'd canonical JSON rather
+    than the binary `SSC2` framing that `parse_header_stream` reads, so a
+    caller inspecting a text container before choosing a credential needs
+    this rather than the file path. Raises `MalformedContainer`, deliberately
+    without detail: the caller is about to decide whether to attempt
+    decryption, and a parse failure should not describe the input back.
+    """
+    import base64
+    import json
+
+    from secure_string_cipher.v2.header_parser import validate_v2_header
+    from secure_string_cipher.v2.message import unarmor_message
+    from secure_string_cipher.v2.vault_schema import _reject_duplicate_object_hook
+
+    try:
+        parsed = unarmor_message(armoured_text)
+        raw_bytes = base64.b64decode(parsed.header_b64, validate=True)
+        header_dict = json.loads(
+            raw_bytes.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_object_hook,
+        )
+        return validate_v2_header(header_dict, raw_bytes)
+    except Exception as error:
+        raise MalformedContainer(error) from error
+
+
+def required_credential(header: V2Header) -> GrantRequirement:
+    """Report what the header's grant requires. Pure; performs no I/O.
+
+    Raises `NoUsableGrant` when the grant type is not one this version can
+    satisfy. A v2 object always carries exactly one grant
+    (`AccessPolicy.SINGLE_GRANT`, enforced in envelope.py), so this inspects
+    that grant rather than searching for a satisfiable one among several.
+    """
+    grants = header.access.grants
+    if not grants:
+        raise NoUsableGrant
+    grant = grants[0]
+
+    if grant.type == GrantType.PASSWORD:
+        return GrantRequirement(CredentialRequirement.PASSWORD)
+
+    if grant.type == GrantType.MANAGED_KEY:
+        if not grant.key_fingerprint:
+            raise NoUsableGrant
+        return GrantRequirement(
+            CredentialRequirement.MANAGED_KEY, grant.key_fingerprint
+        )
+
+    if grant.type == GrantType.COMBINED_PASSWORD_MANAGED_KEY:
+        if not grant.key_fingerprint:
+            raise NoUsableGrant
+        return GrantRequirement(CredentialRequirement.COMBINED, grant.key_fingerprint)
+
+    raise NoUsableGrant
+
+
+# ---------------------------------------------------------------------------
+# Locating a managed key
+# ---------------------------------------------------------------------------
+
+
+def default_keys_dir() -> Path:
+    """The conventional location for managed keyfiles.
+
+    Resolved on each call rather than captured at import time, so that a
+    caller (or a test) which redirects the home directory is honoured.
+    """
+    return Path.home() / ".ssc" / "keys"
+
+
+class KeyResolver:
+    """Turns a key reference into validated keyfile data.
+
+    A reference is either a path to a `.ssckey` file or a fingerprint/key-id
+    belonging to a keyfile in `keys_dir`. Both encryption (`key:ID` sources)
+    and decryption (a grant's recorded fingerprint) use this, so the two
+    sides cannot drift apart in how they interpret a reference.
+    """
+
+    def __init__(self, keys_dir: Path | None = None):
+        self._keys_dir = keys_dir
+
+    @property
+    def keys_dir(self) -> Path:
+        return self._keys_dir if self._keys_dir is not None else default_keys_dir()
+
+    def resolve(self, key_ref: str) -> KeyFileData:
+        """Locate and load the keyfile `key_ref` names.
+
+        Raises `KeyFileUnreadable` if a path was clearly intended but could
+        not be loaded, and `KeyFileNotFound` if nothing matched.
+        """
+        candidate = Path(key_ref).expanduser()
+        if candidate.suffix == ".ssckey" or candidate.is_file():
+            try:
+                return load_keyfile(candidate)
+            except Exception as error:
+                raise KeyFileUnreadable(candidate, error) from error
+
+        keys_dir = self.keys_dir
+        if keys_dir.is_dir():
+            for child in sorted(keys_dir.iterdir()):
+                if child.suffix != ".ssckey":
+                    continue
+                try:
+                    key_data = load_keyfile(child)
+                except Exception:
+                    # A single unreadable or malformed keyfile in the
+                    # directory must not stop the search; the reference may
+                    # well name one of the others.
+                    continue
+                if key_ref in (key_data.fingerprint, key_data.key_id):
+                    return key_data
+
+        raise KeyFileNotFound(key_ref, keys_dir)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle policy
+# ---------------------------------------------------------------------------
+
+
+class KeyStatusPolicy:
+    """Refuses a managed key this vault marks revoked or destroyed.
+
+    Holding a `.ssckey` file is sufficient to use the key it contains, so
+    ordinary encrypt/decrypt reads the file straight off disk and never
+    consults the vault. That is inherent to a bearer secret, not a defect.
+    This check exists for the case where a caller *is* willing to open the
+    vault: it then refuses a key that vault records as revoked or destroyed.
+
+    A key the vault does not track cannot be checked and is allowed through.
+    `ARCHIVED` is bookkeeping only and never blocks use.
+    """
+
+    def __init__(self, service: V2VaultService):
+        self._service = service
+
+    def check(self, fingerprint: str, *, master_password: str) -> None:
+        """Raise if the vault marks `fingerprint` unusable.
+
+        Raises `VaultUnlockFailed` if the vault cannot be read, and
+        `KeyStatusRejected` if it records the key as revoked or destroyed.
+        """
+        try:
+            records = self._service.list_keys(master_password)
+        except Exception as error:
+            raise VaultUnlockFailed(error) from error
+
+        for record in records:
+            if record.fingerprint != fingerprint:
+                continue
+            if record.status in (KeyStatus.REVOKED, KeyStatus.DESTROYED):
+                raise KeyStatusRejected(record.id, record.status)
+            return
+
+
+# ---------------------------------------------------------------------------
+# Assembling a credential
+# ---------------------------------------------------------------------------
+
+
+def build_credential(
+    requirement: GrantRequirement,
+    *,
+    password: str | None = None,
+    key_data: KeyFileData | None = None,
+) -> V2Credential:
+    """Assemble the credential `requirement` describes from supplied parts.
+
+    The fingerprint recorded in the grant is used rather than the resolved
+    keyfile's own, so that a caller who pointed at a different file still
+    produces a credential naming what the DEK was wrapped against — and the
+    resulting mismatch surfaces as an authentication failure rather than
+    silently succeeding against the wrong identity.
+    """
+    if requirement.needs_password and password is None:
+        raise ValueError("this grant requires a password")
+    if requirement.needs_managed_key and key_data is None:
+        raise ValueError("this grant requires a managed key")
+
+    if requirement.requirement == CredentialRequirement.PASSWORD:
+        assert password is not None
+        return PasswordCredential(passphrase=password)
+
+    fingerprint = requirement.key_fingerprint
+    if not fingerprint:
+        raise NoUsableGrant
+    assert key_data is not None
+
+    if requirement.requirement == CredentialRequirement.MANAGED_KEY:
+        return KeyCredential(
+            key_fingerprint=fingerprint, managed_secret=key_data.secret_bytes
+        )
+
+    assert password is not None
+    return CombinedCredential(
+        passphrase=password,
+        key_fingerprint=fingerprint,
+        managed_secret=key_data.secret_bytes,
+    )

--- a/src/secure_string_cipher/v2/app.py
+++ b/src/secure_string_cipher/v2/app.py
@@ -37,6 +37,7 @@ from secure_string_cipher.v2.vault_service import V2VaultService
 __all__ = [
     "CredentialRequirement",
     "GrantRequirement",
+    "KeyDirectoryUnreadable",
     "KeyResolver",
     "KeyStatusPolicy",
     "KeyFileNotFound",
@@ -81,6 +82,20 @@ class KeyFileUnreadable(V2AppError):
         self.path = path
         self.cause = cause
         super().__init__(f"Could not load key file: {path}")
+
+
+class KeyDirectoryUnreadable(V2AppError):
+    """The keys directory exists but could not be searched.
+
+    Distinct from `KeyFileNotFound`: the reference may well have matched, but
+    the directory could not be read to find out. Reporting "not found" for an
+    unreadable directory would send the caller looking for the wrong problem.
+    """
+
+    def __init__(self, keys_dir: Path, cause: BaseException):
+        self.keys_dir = keys_dir
+        self.cause = cause
+        super().__init__(f"Could not search the keys directory: {keys_dir}")
 
 
 class KeyStatusRejected(V2AppError):
@@ -264,7 +279,16 @@ class KeyResolver:
 
         keys_dir = self.keys_dir
         if keys_dir.is_dir():
-            for child in sorted(keys_dir.iterdir()):
+            try:
+                children = sorted(keys_dir.iterdir())
+            except OSError as error:
+                # An unreadable directory, or one removed between the is_dir
+                # check and the listing, would otherwise raise a bare
+                # PermissionError/OSError straight past the V2AppError
+                # hierarchy this module advertises.
+                raise KeyDirectoryUnreadable(keys_dir, error) from error
+
+            for child in children:
                 if child.suffix != ".ssckey":
                     continue
                 try:

--- a/tests/unit/test_v2_app_layer.py
+++ b/tests/unit/test_v2_app_layer.py
@@ -7,6 +7,7 @@ reintroduces `getpass` or `sys.exit` into this module, the tests that drive
 it headlessly are what will notice.
 """
 
+import os
 import secrets
 from pathlib import Path
 
@@ -15,6 +16,7 @@ import pytest
 from secure_string_cipher.v2.app import (
     CredentialRequirement,
     GrantRequirement,
+    KeyDirectoryUnreadable,
     KeyFileNotFound,
     KeyFileUnreadable,
     KeyResolver,
@@ -132,6 +134,29 @@ class TestKeyResolver:
         (tmp_path / "broken.ssckey").write_text("garbage\n")
         _, good = _write_keyfile(tmp_path, "good-key")
         assert KeyResolver(tmp_path).resolve("good-key").fingerprint == good.fingerprint
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission semantics")
+    def test_unreadable_keys_directory_raises_a_typed_error(
+        self, tmp_path: Path
+    ) -> None:
+        """An unreadable directory must not raise a bare PermissionError.
+
+        The layer advertises that every failure is a V2AppError; a raw
+        filesystem exception escaping past that breaks the contract for any
+        caller writing `except V2AppError`. It is also reported distinctly
+        from "not found", since the reference may well have matched.
+        """
+        keys_dir = tmp_path / "keys"
+        keys_dir.mkdir()
+        os.chmod(keys_dir, 0o000)
+        try:
+            with pytest.raises(KeyDirectoryUnreadable) as excinfo:
+                KeyResolver(keys_dir).resolve("anything")
+            assert isinstance(excinfo.value, V2AppError)
+            assert isinstance(excinfo.value.cause, OSError)
+            assert excinfo.value.keys_dir == keys_dir
+        finally:
+            os.chmod(keys_dir, 0o700)
 
     def test_missing_keys_directory_is_not_an_error_in_itself(
         self, tmp_path: Path
@@ -266,6 +291,7 @@ class TestLayerIsHeadless:
         """A caller can handle the whole layer without enumerating classes."""
         for error in (
             KeyFileNotFound("x", Path("/k")),
+            KeyDirectoryUnreadable(Path("/k"), OSError("denied")),
             KeyFileUnreadable(Path("/k/x.ssckey"), OSError("boom")),
             KeyStatusRejected("k", KeyStatus.REVOKED),
             VaultUnlockFailed(),

--- a/tests/unit/test_v2_app_layer.py
+++ b/tests/unit/test_v2_app_layer.py
@@ -1,0 +1,295 @@
+"""Tests for the reusable v2 application layer.
+
+The defining property of this layer is what it does *not* do: no prompting,
+no process exit. Everything here therefore runs with no TTY attached and
+asserts on returned values or raised exceptions. If a future change
+reintroduces `getpass` or `sys.exit` into this module, the tests that drive
+it headlessly are what will notice.
+"""
+
+import secrets
+from pathlib import Path
+
+import pytest
+
+from secure_string_cipher.v2.app import (
+    CredentialRequirement,
+    GrantRequirement,
+    KeyFileNotFound,
+    KeyFileUnreadable,
+    KeyResolver,
+    KeyStatusPolicy,
+    KeyStatusRejected,
+    NoUsableGrant,
+    V2AppError,
+    VaultUnlockFailed,
+    build_credential,
+    default_keys_dir,
+    header_from_armour,
+    required_credential,
+)
+from secure_string_cipher.v2.encrypt import (
+    CombinedCredential,
+    KeyCredential,
+    PasswordCredential,
+    encrypt_v2_text,
+)
+from secure_string_cipher.v2.envelope import V2Header
+from secure_string_cipher.v2.key_identity import KeyStatus, compute_fingerprint
+from secure_string_cipher.v2.keyfile import KeyFileData, save_keyfile
+
+PASSWORD = "Str0ngPassphrase!2026"  # pragma: allowlist secret
+# Stub master passwords. Named constants rather than inline literals so the
+# allowlist pragma cannot be detached from them by the formatter.
+MASTER = "stub-master"  # pragma: allowlist secret
+WRONG_MASTER = "stub-wrong"  # pragma: allowlist secret
+
+
+def _write_keyfile(directory: Path, key_id: str) -> tuple[Path, KeyFileData]:
+    secret = secrets.token_bytes(32)
+    data = KeyFileData(
+        version=1,
+        key_id=key_id,
+        key_type="symmetric-key",
+        kdf="hkdf-sha256",
+        fingerprint=compute_fingerprint(secret),
+        created_at="2026-09-12T00:00:00Z",
+        secret_bytes=secret,
+    )
+    path = directory / f"{key_id}.ssckey"
+    save_keyfile(data, path)
+    return path, data
+
+
+def _header_for(credential) -> V2Header:
+    """Seal a real object and hand back its parsed header."""
+    return header_from_armour(encrypt_v2_text("probe", credential))
+
+
+class TestRequiredCredential:
+    """`required_credential` is pure: it inspects a header and nothing else."""
+
+    def test_password_grant(self) -> None:
+        header = _header_for(PasswordCredential(PASSWORD))
+        req = required_credential(header)
+        assert req.requirement is CredentialRequirement.PASSWORD
+        assert req.needs_password and not req.needs_managed_key
+        assert req.key_fingerprint is None
+
+    def test_managed_key_grant(self, tmp_path: Path) -> None:
+        _, data = _write_keyfile(tmp_path, "probe-key")
+        header = _header_for(KeyCredential(data.fingerprint, data.secret_bytes))
+        req = required_credential(header)
+        assert req.requirement is CredentialRequirement.MANAGED_KEY
+        assert req.needs_managed_key and not req.needs_password
+        assert req.key_fingerprint == data.fingerprint
+
+    def test_combined_grant(self, tmp_path: Path) -> None:
+        _, data = _write_keyfile(tmp_path, "probe-key")
+        header = _header_for(
+            CombinedCredential(PASSWORD, data.fingerprint, data.secret_bytes)
+        )
+        req = required_credential(header)
+        assert req.requirement is CredentialRequirement.COMBINED
+        assert req.needs_password and req.needs_managed_key
+        assert req.key_fingerprint == data.fingerprint
+
+
+class TestKeyResolver:
+    def test_resolves_an_explicit_path(self, tmp_path: Path) -> None:
+        path, data = _write_keyfile(tmp_path, "by-path")
+        assert KeyResolver().resolve(str(path)).fingerprint == data.fingerprint
+
+    def test_resolves_by_key_id_from_the_keys_directory(self, tmp_path: Path) -> None:
+        _, data = _write_keyfile(tmp_path, "by-id")
+        assert KeyResolver(tmp_path).resolve("by-id").fingerprint == data.fingerprint
+
+    def test_resolves_by_fingerprint_from_the_keys_directory(
+        self, tmp_path: Path
+    ) -> None:
+        _, data = _write_keyfile(tmp_path, "by-fingerprint")
+        resolved = KeyResolver(tmp_path).resolve(data.fingerprint)
+        assert resolved.key_id == "by-fingerprint"
+
+    def test_unknown_reference_raises_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(KeyFileNotFound) as excinfo:
+            KeyResolver(tmp_path).resolve("no-such-key")
+        assert excinfo.value.key_ref == "no-such-key"
+        assert str(tmp_path) in str(excinfo.value)
+
+    def test_corrupt_keyfile_at_an_explicit_path_raises_unreadable(
+        self, tmp_path: Path
+    ) -> None:
+        bad = tmp_path / "broken.ssckey"
+        bad.write_text("not a keyfile at all\n")
+        with pytest.raises(KeyFileUnreadable) as excinfo:
+            KeyResolver(tmp_path).resolve(str(bad))
+        assert excinfo.value.path == bad
+        assert excinfo.value.cause is not None
+
+    def test_one_corrupt_keyfile_does_not_hide_the_others(self, tmp_path: Path) -> None:
+        """A malformed neighbour must not abort the directory search."""
+        (tmp_path / "broken.ssckey").write_text("garbage\n")
+        _, good = _write_keyfile(tmp_path, "good-key")
+        assert KeyResolver(tmp_path).resolve("good-key").fingerprint == good.fingerprint
+
+    def test_missing_keys_directory_is_not_an_error_in_itself(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(KeyFileNotFound):
+            KeyResolver(tmp_path / "absent").resolve("anything")
+
+    def test_default_keys_directory_follows_the_current_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolved per call, not captured at import time."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        assert default_keys_dir() == tmp_path / ".ssc" / "keys"
+        assert KeyResolver().keys_dir == tmp_path / ".ssc" / "keys"
+
+
+class _StubService:
+    """Stands in for V2VaultService without needing a real vault."""
+
+    def __init__(self, records=None, error: Exception | None = None):
+        self._records = records or []
+        self._error = error
+        self.seen_password: str | None = None
+
+    def list_keys(self, master_password: str):
+        self.seen_password = master_password
+        if self._error is not None:
+            raise self._error
+        return self._records
+
+
+class _Record:
+    def __init__(self, key_id: str, fingerprint: str, status: KeyStatus):
+        self.id = key_id
+        self.fingerprint = fingerprint
+        self.status = status
+
+
+class TestKeyStatusPolicy:
+    FP = "ssc-k1-" + "A" * 52
+
+    def test_active_key_passes(self) -> None:
+        service = _StubService([_Record("k", self.FP, KeyStatus.ACTIVE)])
+        KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+        assert service.seen_password == MASTER, (
+            "the password must be injected, not read"
+        )
+
+    def test_archived_key_passes(self) -> None:
+        """Archive is bookkeeping only; it never blocks use."""
+        service = _StubService([_Record("k", self.FP, KeyStatus.ARCHIVED)])
+        KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+
+    @pytest.mark.parametrize("status", [KeyStatus.REVOKED, KeyStatus.DESTROYED])
+    def test_revoked_or_destroyed_key_is_rejected(self, status: KeyStatus) -> None:
+        service = _StubService([_Record("laptop", self.FP, status)])
+        with pytest.raises(KeyStatusRejected) as excinfo:
+            KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+        assert excinfo.value.key_id == "laptop"
+        assert excinfo.value.status is status
+        assert "laptop" in str(excinfo.value)
+
+    def test_untracked_key_is_allowed_through(self) -> None:
+        """A bare .ssckey this vault never registered cannot be judged."""
+        other = "ssc-k1-" + "B" * 52
+        service = _StubService([_Record("k", other, KeyStatus.REVOKED)])
+        KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+
+    def test_unopenable_vault_raises_rather_than_silently_allowing(self) -> None:
+        service = _StubService(error=RuntimeError("bad master password"))
+        with pytest.raises(VaultUnlockFailed) as excinfo:
+            KeyStatusPolicy(service).check(self.FP, master_password=WRONG_MASTER)
+        assert isinstance(excinfo.value.cause, RuntimeError)
+
+
+class TestBuildCredential:
+    FP = "ssc-k1-" + "C" * 52
+
+    def _key_data(self) -> KeyFileData:
+        secret = secrets.token_bytes(32)
+        return KeyFileData(
+            version=1,
+            key_id="k",
+            key_type="symmetric-key",
+            kdf="hkdf-sha256",
+            fingerprint=compute_fingerprint(secret),
+            created_at="2026-09-12T00:00:00Z",
+            secret_bytes=secret,
+        )
+
+    def test_builds_each_credential_type(self) -> None:
+        data = self._key_data()
+        password_only = build_credential(
+            GrantRequirement(CredentialRequirement.PASSWORD), password=PASSWORD
+        )
+        assert isinstance(password_only, PasswordCredential)
+
+        key_only = build_credential(
+            GrantRequirement(CredentialRequirement.MANAGED_KEY, self.FP), key_data=data
+        )
+        assert isinstance(key_only, KeyCredential)
+
+        combined = build_credential(
+            GrantRequirement(CredentialRequirement.COMBINED, self.FP),
+            password=PASSWORD,
+            key_data=data,
+        )
+        assert isinstance(combined, CombinedCredential)
+
+    def test_uses_the_grant_fingerprint_not_the_keyfile_one(self) -> None:
+        """A caller may point at a different file; the grant still names the
+        identity the DEK was wrapped against, so a mismatch must surface as an
+        authentication failure rather than silently succeeding."""
+        data = self._key_data()
+        credential = build_credential(
+            GrantRequirement(CredentialRequirement.MANAGED_KEY, self.FP), key_data=data
+        )
+        assert credential.key_fingerprint == self.FP != data.fingerprint
+
+    def test_missing_parts_are_refused(self) -> None:
+        with pytest.raises(ValueError, match="requires a password"):
+            build_credential(GrantRequirement(CredentialRequirement.PASSWORD))
+        with pytest.raises(ValueError, match="requires a managed key"):
+            build_credential(
+                GrantRequirement(CredentialRequirement.MANAGED_KEY, self.FP)
+            )
+
+
+class TestLayerIsHeadless:
+    def test_every_app_error_is_catchable_as_one_type(self) -> None:
+        """A caller can handle the whole layer without enumerating classes."""
+        for error in (
+            KeyFileNotFound("x", Path("/k")),
+            KeyFileUnreadable(Path("/k/x.ssckey"), OSError("boom")),
+            KeyStatusRejected("k", KeyStatus.REVOKED),
+            VaultUnlockFailed(),
+            NoUsableGrant(),
+        ):
+            assert isinstance(error, V2AppError)
+            assert str(error), "each error must carry a renderable message"
+
+    def test_a_full_headless_round_trip(self, tmp_path: Path) -> None:
+        """Resolve, check status and build a credential with no TTY involved.
+
+        This is the path a TUI or library caller would take, and the one that
+        previously could not exist because the equivalent CLI helpers called
+        sys.exit and getpass.
+        """
+        _, data = _write_keyfile(tmp_path, "headless")
+        header = _header_for(KeyCredential(data.fingerprint, data.secret_bytes))
+
+        requirement = required_credential(header)
+        resolved = KeyResolver(tmp_path).resolve(requirement.key_fingerprint or "")
+        KeyStatusPolicy(
+            _StubService([_Record("headless", data.fingerprint, KeyStatus.ACTIVE)])
+        ).check(data.fingerprint, master_password=MASTER)
+        credential = build_credential(requirement, key_data=resolved)
+
+        assert isinstance(credential, KeyCredential)
+        assert credential.key_fingerprint == data.fingerprint


### PR DESCRIPTION
Closes the extraction half of **#93** — the structural blocker for #99 (interactive v2 support).

## Why

V2's credential model lived inside the CLI adapter and could not be used from anywhere else:

| helper | responsibility |
|---|---|
| `_resolve_v2_key_source` | key discovery (`key:ID`, path, `~/.ssc/keys/` scan) |
| `_enforce_v2_key_status` | lifecycle policy — the **only** place a revoked/destroyed key is refused on the external-key path |
| `_resolve_v2_credential_from_header` | header → credential |

All three called `_exit_error()` (`sys.exit`) and `_prompt_master_password()` (`getpass`) internally. A TUI calling the key-status check would have **terminated the application** instead of showing an error, and blocked on a terminal prompt. So the practical choice for a second surface was to duplicate a security control or go without it.

## What

New `secure_string_cipher/v2/app.py`:

```python
required_credential(header)    # pure; what the grant requires
header_from_armour(text)       # protected header out of an armoured message
KeyResolver                    # reference -> validated KeyFileData
KeyStatusPolicy                # refuses revoked/destroyed; password injected
build_credential(...)          # assembles a credential from parts
```

- **Nothing prompts and nothing exits.** Failures are typed under a common `V2AppError` base, so a caller can handle the layer without enumerating classes.
- **Obtaining a password is deliberately excluded.** A prompt, a vault entry, a file or an env var are all interface concerns — that stays with the caller. This is what keeps the layer usable from a TUI, a library, or #94's non-interactive sources without the layer needing to know which.
- `keys_dir` is a parameter, and the default resolves **per call** rather than at import, so a redirected home is honoured.
- `cli_args.py` becomes an adapter over it.

## Behaviour

Unchanged, with one deliberate improvement: "key not found" now names the resolved keys directory rather than a literal `~/.ssc/keys/`.

Also removed from the CLI: the inline armour-header parsing block, and two of the broad `except Exception` handlers in the credential path.

Per the project's own `tools/check_sensitive_output.py`, the adapter composes its messages from the exceptions' **structured attributes** rather than their text, with values hoisted into locals so no exception name appears in a sink call. That guard blocked my first two attempts and was right to — worth noting it works.

## Verification

- **22 new tests drive the layer entirely headlessly** — no TTY, no `SystemExit`. That property could not be tested at all before, and is what will notice if `getpass`/`sys.exit` ever reappear here.
- Full suite **1653 passing** (1631 + 22); `ruff`, `mypy src`, and the sensitive-output guard clean
- Live CLI checks by hand: v2 managed-key encrypt→decrypt round trip, and the key-not-found path still exiting 4

## Not in this PR

- The remaining ~20 broad `except Exception` handlers in `cmd_key_*`/`cmd_vault_*` — they stay on #93; this PR only covers the credential path it restructures
- The stability tier for this module (#98). It is importable but not yet re-exported from `v2/__init__.py`, so that decision isn't pre-empted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)