### PR TITLE
feat(cli): supply passwords from a file or the environment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "README.md",
         "hashed_secret": "eeb7f851dfdec7a9f083802e5454d0c98fa9d616",
         "is_verified": false,
-        "line_number": 410
+        "line_number": 436
       }
     ],
     "src/secure_string_cipher/audit_log.py": [
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 452
+        "line_number": 542
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T20:57:08Z"
+  "generated_at": "2026-09-12T21:08:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 452
+        "line_number": 453
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T20:57:08Z"
+  "generated_at": "2026-09-12T21:12:58Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "README.md",
         "hashed_secret": "eeb7f851dfdec7a9f083802e5454d0c98fa9d616",
         "is_verified": false,
-        "line_number": 436
+        "line_number": 446
       }
     ],
     "src/secure_string_cipher/audit_log.py": [
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 543
+        "line_number": 618
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T21:14:40Z"
+  "generated_at": "2026-09-12T21:59:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 440
+        "line_number": 452
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T10:44:54Z"
+  "generated_at": "2026-09-12T20:57:08Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- **Non-interactive credentials: `--password-file` / `SSC_PASSWORD` and
+  `--master-password-file` / `SSC_MASTER_PASSWORD`.** There was previously no
+  way to supply a password without a prompt, so v2 password mode and v2
+  combined mode could not be scripted at all, and anything touching the vault
+  required an interactive master password. Piping worked only via CPython's
+  degraded `getpass` fallback, which prints a warning and has no Windows
+  equivalent. The flag takes precedence over the variable. A password file
+  must be a regular file, not reached through a symlink, and on POSIX not
+  group/other-readable; one trailing newline is stripped; an empty,
+  oversized or non-UTF-8 file is refused. A supplied password is still
+  strength-checked where a new password is being set, and fails rather than
+  looping since it cannot be re-prompted.
+
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,
   header→requirement mapping, armoured-header parsing and credential

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@
   group/other-readable; one trailing newline is stripped; an empty,
   oversized or non-UTF-8 file is refused. A supplied password is still
   strength-checked where a new password is being set, and fails rather than
-  looping since it cannot be re-prompted.
+  looping since it cannot be re-prompted. A third source,
+  `--new-master-password-file` / `SSC_NEW_MASTER_PASSWORD`, supplies the
+  replacement value for `ssc vault change-password`: setting a master
+  password and using one are separate roles, and a single value read as both
+  would re-encrypt the vault with the password it already had while
+  reporting a successful rotation. That command now refuses to run when only
+  the current password was supplied, and refuses a new password equal to the
+  old one.
 
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`secure_string_cipher.v2.app` — a reusable application layer for v2
+  credentials and managed-key policy.** Key resolution, key-status policy,
+  header→requirement mapping, armoured-header parsing and credential
+  assembly previously lived in `cli_args.py` as private helpers that called
+  `sys.exit()` and `getpass()` directly, so no other interface could use
+  them: a second surface calling the key-status check would have terminated
+  the process rather than reporting an error. The new module performs no
+  interactive input and never exits; it raises typed errors under a common
+  `V2AppError` base. Obtaining a password stays with the caller, since where
+  a password comes from is an interface concern. `cli_args.py` is now an
+  adapter over it with identical behaviour. Its stability tier is still to
+  be decided — the module is importable but not yet re-exported.
+
 ### Fixed
 
 - **Stale "V2 not yet released" banners.** `docs/API.md`'s "V2 Encryption"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ contain accepted changes that have not yet been included in a release.
 
 For scripting and automation, use the `ssc` command:
 
+#### Supplying credentials without a prompt
+
+Passwords are read interactively by default. For automation, supply them
+from a file or the environment:
+
+```bash
+# The data password
+ssc --password-file /run/secrets/pw encrypt -f document.pdf --with password
+SSC_PASSWORD="..." ssc encrypt -f document.pdf --with password
+
+# The vault master password, for vault and key commands
+ssc --master-password-file /run/secrets/master key list
+SSC_MASTER_PASSWORD="..." ssc key list
+```
+
+The flag wins over the variable, so a stale exported value cannot quietly
+override what the command line asked for. A password file must be a regular
+file, not reached through a symlink, and on POSIX not readable by group or
+other — it is a bearer secret, so a world-readable one is refused rather
+than used with a warning. One trailing newline is removed, since a file
+written with `echo` has one.
+
+Prefer a file over an environment variable where you can: on some systems a
+process's environment is readable by other processes owned by the same user,
+and variables are easily captured in shell history and CI logs.
+
 ```bash
 # Encrypt text
 ssc encrypt -t "Secret message"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,17 @@ SSC_PASSWORD="..." ssc encrypt -f document.pdf --with password
 # The vault master password, for vault and key commands
 ssc --master-password-file /run/secrets/master key list
 SSC_MASTER_PASSWORD="..." ssc key list
+
+# Rotating the master password needs both values, since one of them is
+# being replaced
+ssc --master-password-file /run/secrets/old \
+    --new-master-password-file /run/secrets/new vault change-password
 ```
+
+Setting a master password and using one are separate roles, so they have
+separate sources. `vault change-password` refuses to run if only the
+current one was supplied: reusing it would re-encrypt the vault with the
+password it already has and report a successful rotation.
 
 The flag wins over the variable, so a stale exported value cannot quietly
 override what the command line asked for. A password file must be a regular

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -57,6 +57,19 @@ from .rate_limiter import PersistentRateLimiter, RateLimitError
 from .security import SecurityError
 from .timing_safe import check_password_strength
 from .utils import colorize, secure_overwrite
+from .v2.app import (
+    KeyFileNotFound,
+    KeyFileUnreadable,
+    KeyResolver,
+    KeyStatusPolicy,
+    KeyStatusRejected,
+    MalformedContainer,
+    NoUsableGrant,
+    VaultUnlockFailed,
+    build_credential,
+    header_from_armour,
+    required_credential,
+)
 from .v2.decrypt import decrypt_v2_file, decrypt_v2_text
 from .v2.encrypt import (
     CombinedCredential,
@@ -66,8 +79,7 @@ from .v2.encrypt import (
     encrypt_v2_file,
     encrypt_v2_text,
 )
-from .v2.key_identity import KeyStatus
-from .v2.keyfile import KeyFileData, load_keyfile
+from .v2.keyfile import KeyFileData
 from .v2.keywrap import KeyWrapError
 from .v2.vault_lock import VaultBusyError
 from .v2.vault_service import (
@@ -862,37 +874,25 @@ def _get_v1_password(args: argparse.Namespace) -> str:
 
 
 def _resolve_v2_key_source(key_ref: str) -> KeyFileData:
-    """Resolve a V2 key reference to validated keyfile data.
+    """CLI adapter over ``v2.app.KeyResolver``.
 
-    ``key_ref`` is either a path to a ``.ssckey`` file or a fingerprint/key-id
-    registered under ``~/.ssc/keys/``. Shared by encryption (``key:X`` sources)
-    and decryption (``--key-file`` or header grant fingerprints) so both sides
-    use one resolution model. ``load_keyfile`` always receives a ``Path``.
+    The resolution logic itself lives in the application layer so the
+    interactive menu and library callers can use it; this wrapper only turns
+    its typed errors into CLI exits.
     """
-    candidate = Path(key_ref).expanduser()
-    if candidate.suffix == ".ssckey" or candidate.is_file():
-        try:
-            return load_keyfile(candidate)
-        except Exception:
-            _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
-
-    keys_dir = Path.home() / ".ssc" / "keys"
-    if keys_dir.is_dir():
-        for child in sorted(keys_dir.iterdir()):
-            if child.suffix != ".ssckey":
-                continue
-            try:
-                key_data = load_keyfile(child)
-            except Exception:
-                continue
-            if key_ref in (key_data.fingerprint, key_data.key_id):
-                return key_data
-
-    _exit_error(
-        EXIT_FILE_ERROR,
-        "Key not found: provide a .ssckey path or a fingerprint/key-id "
-        "present in ~/.ssc/keys/.",
-    )
+    try:
+        return KeyResolver().resolve(key_ref)
+    except KeyFileUnreadable:
+        _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
+    except KeyFileNotFound as error:
+        # Hoisted out of the message expression so no exception name appears
+        # in the sink call itself (tools/check_sensitive_output.py).
+        keys_dir = error.keys_dir
+        _exit_error(
+            EXIT_FILE_ERROR,
+            "Key not found: provide a .ssckey path or a fingerprint/key-id "
+            f"present in {keys_dir}.",
+        )
 
 
 def _get_v2_password(args: argparse.Namespace) -> str:
@@ -919,105 +919,65 @@ def _enforce_v2_key_status(fingerprint: str) -> None:
     if not vault.vault_exists():
         return
     master = _prompt_master_password()
-    service = V2VaultService(vault)
     try:
-        records = service.list_keys(master)
-    except Exception:
+        KeyStatusPolicy(V2VaultService(vault)).check(
+            fingerprint, master_password=master
+        )
+    except KeyStatusRejected as error:
+        rejected_id, rejected_status = error.key_id, error.status.value
+        _exit_error(
+            EXIT_AUTH_ERROR,
+            f"Key '{rejected_id}' is {rejected_status} in this vault; "
+            "refusing to use it.",
+        )
+    except VaultUnlockFailed:
         _exit_error(EXIT_AUTH_ERROR, "Could not unlock vault to check key status.")
-    for record in records:
-        if record.fingerprint != fingerprint:
-            continue
-        if record.status == KeyStatus.REVOKED:
-            _exit_error(
-                EXIT_AUTH_ERROR,
-                f"Key '{record.id}' is revoked in this vault; refusing to use it.",
-            )
-        if record.status == KeyStatus.DESTROYED:
-            _exit_error(
-                EXIT_AUTH_ERROR,
-                f"Key '{record.id}' has been destroyed in this vault; refusing "
-                "to use it.",
-            )
-        return
 
 
 def _resolve_v2_credential_from_header(
     header: V2Header, args: argparse.Namespace
 ) -> V2Credential:
-    from .v2.envelope import GrantType
+    """CLI adapter: obtain whatever the header's grant requires.
 
-    has_password = any(g.type == GrantType.PASSWORD for g in header.access.grants)
-    has_key = any(g.type == GrantType.MANAGED_KEY for g in header.access.grants)
-    has_combined = any(
-        g.type == GrantType.COMBINED_PASSWORD_MANAGED_KEY for g in header.access.grants
-    )
+    Deciding *what* is required, and assembling the credential, live in
+    ``v2.app``. What remains here is the interface's own business: where a
+    password comes from, how ``--key-file`` overrides the grant's named key,
+    and how failures map to exit codes.
+    """
+    try:
+        requirement = required_credential(header)
+    except NoUsableGrant:
+        _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
 
     key_file_ref = getattr(args, "key_file", None)
-
-    if has_combined:
-        password = _get_v2_password(args)
-        grant = next(
-            g
-            for g in header.access.grants
-            if g.type == GrantType.COMBINED_PASSWORD_MANAGED_KEY
+    if key_file_ref and not requirement.needs_managed_key:
+        _exit_error(
+            EXIT_INPUT_ERROR,
+            "--key-file is only usable with V2 key-protected containers.",
         )
-        if not grant.key_fingerprint:
-            _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
-        key_data = _resolve_v2_key_source(key_file_ref or grant.key_fingerprint)
+
+    password = _get_v2_password(args) if requirement.needs_password else None
+
+    key_data = None
+    if requirement.needs_managed_key:
+        assert requirement.key_fingerprint is not None
+        key_data = _resolve_v2_key_source(key_file_ref or requirement.key_fingerprint)
         if getattr(args, "vault", None):
-            _enforce_v2_key_status(grant.key_fingerprint)
-        return CombinedCredential(
-            passphrase=password,
-            key_fingerprint=grant.key_fingerprint,
-            managed_secret=key_data.secret_bytes,
-        )
+            _enforce_v2_key_status(requirement.key_fingerprint)
 
-    if has_password:
-        if key_file_ref:
-            _exit_error(
-                EXIT_INPUT_ERROR,
-                "--key-file is only usable with V2 key-protected containers.",
-            )
-        password = _get_v2_password(args)
-        return PasswordCredential(passphrase=password)
-
-    if has_key:
-        grant = next(g for g in header.access.grants if g.type == GrantType.MANAGED_KEY)
-        if not grant.key_fingerprint:
-            _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
-        key_data = _resolve_v2_key_source(key_file_ref or grant.key_fingerprint)
-        if getattr(args, "vault", None):
-            _enforce_v2_key_status(grant.key_fingerprint)
-        return KeyCredential(
-            key_fingerprint=grant.key_fingerprint, managed_secret=key_data.secret_bytes
-        )
-
-    _exit_error(EXIT_AUTH_ERROR, "No usable access grant found in V2 header.")
+    return build_credential(requirement, password=password, key_data=key_data)
 
 
 def _cmd_decrypt_v2(
     args: argparse.Namespace, is_message: bool, rate_identifier: str = ""
 ) -> int:
-    import base64
-    import json
 
-    from .v2.header_parser import parse_header_stream, validate_v2_header
-    from .v2.message import unarmor_message
-    from .v2.vault_schema import _reject_duplicate_object_hook
+    from .v2.header_parser import parse_header_stream
 
     if is_message:
-        # Armored messages carry the header as raw canonical JSON (Base64),
-        # not the binary SSC2 framing parse_header_stream expects. Mirror
-        # decrypt_v2_text: unarmor, decode, then validate the JSON header.
         try:
-            parsed = unarmor_message(args.text)
-            raw_bytes = base64.b64decode(parsed.header_b64, validate=True)
-            header_dict = json.loads(
-                raw_bytes.decode("utf-8"),
-                object_pairs_hook=_reject_duplicate_object_hook,
-            )
-            header = validate_v2_header(header_dict, raw_bytes)
-        except Exception:
+            header = header_from_armour(args.text)
+        except MalformedContainer:
             _cli_limiter.record_attempt("decrypt_text", "", success=False)
             _audit_encryption(AuditEvent.DECRYPT_TEXT, False, error="decryption_failed")
             _exit_error(EXIT_AUTH_ERROR, _V2_DECRYPT_FAILURE_MESSAGE)

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -81,6 +81,7 @@ from .v2.encrypt import (
 )
 from .v2.keyfile import KeyFileData
 from .v2.keywrap import KeyWrapError
+from .v2.paths import reject_symlink_components
 from .v2.vault_lock import VaultBusyError
 from .v2.vault_service import (
     KeyExportSurvivedRegistrationFailureError,
@@ -112,6 +113,16 @@ _V2_DECRYPT_FAILURE_MESSAGE = "Decryption failed. Wrong password/key or corrupte
 _quiet_mode = False
 _no_color = False
 _debug_mode = False
+
+# Non-interactive credential sources, resolved once in main(). Held as module
+# state for the same reason as the flags above: the prompt helpers are called
+# from many places that have no access to the parsed arguments.
+_password_source: str | None = None
+_master_password_source: str | None = None
+
+# A password file is read with the same bound v2 applies to a password before
+# derivation, so an oversized file is refused rather than fed to Argon2id.
+_MAX_PASSWORD_FILE_BYTES = 65536
 
 
 class _StdinSizeError(CryptoError):
@@ -261,16 +272,83 @@ def _audit_rate_limit(operation: str, wait: float, identifier: str = "") -> None
 # =============================================================================
 
 
+def _read_password_file(path_str: str, *, role: str) -> str:
+    """Read a credential from a file, refusing an unsafe or implausible one.
+
+    Held to the same standard as a `.ssckey`: a regular file, not reached
+    through a symlink, and on POSIX not readable by group or other. A password
+    file is a bearer secret, so a world-readable one is refused rather than
+    used with a warning.
+
+    One trailing line ending is removed — a file written with `echo` has one
+    and the operator does not intend it as part of the password — using the
+    same helper as the stdin path so both agree.
+    """
+    path = Path(path_str).expanduser()
+    try:
+        reject_symlink_components(path)
+        if not path.is_file():
+            _exit_error(EXIT_FILE_ERROR, f"{role} file is not a regular file: {path}")
+        if os.name == "posix" and (path.stat().st_mode & 0o077):
+            _exit_error(
+                EXIT_FILE_ERROR,
+                f"{role} file is readable by group or other: {path}. "
+                "Restrict it with chmod 600.",
+            )
+        with open(path, "rb") as handle:
+            raw = handle.read(_MAX_PASSWORD_FILE_BYTES + 1)
+    except OSError as error:
+        detail = error.strerror or "could not be read"
+        _exit_error(EXIT_FILE_ERROR, f"{role} file {detail}: {path}")
+
+    if len(raw) > _MAX_PASSWORD_FILE_BYTES:
+        _exit_error(EXIT_INPUT_ERROR, f"{role} file exceeds the permitted length.")
+
+    value = _remove_one_terminal_line_ending(raw)
+    if not value:
+        _exit_error(EXIT_INPUT_ERROR, f"{role} file is empty: {path}")
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError:
+        _exit_error(EXIT_INPUT_ERROR, f"{role} file is not valid UTF-8: {path}")
+
+
+def _resolve_credential_sources(args: argparse.Namespace) -> None:
+    """Record any non-interactive credential sources the operator supplied.
+
+    An explicit flag wins over an environment variable: naming a file is the
+    more deliberate act, and it keeps a stale exported variable from quietly
+    overriding what the command line asked for.
+    """
+    global _password_source, _master_password_source
+
+    if getattr(args, "password_file", None):
+        _password_source = _read_password_file(args.password_file, role="Password")
+    elif os.environ.get("SSC_PASSWORD"):
+        _password_source = os.environ["SSC_PASSWORD"]
+
+    if getattr(args, "master_password_file", None):
+        _master_password_source = _read_password_file(
+            args.master_password_file, role="Master password"
+        )
+    elif os.environ.get("SSC_MASTER_PASSWORD"):
+        _master_password_source = os.environ["SSC_MASTER_PASSWORD"]
+
+
 def _prompt_password(prompt: str = "Password: ", confirm: bool = False) -> str:
-    """Prompt for password with hidden input.
+    """Obtain the data password, without prompting if a source was supplied.
 
     Args:
         prompt: The prompt to display
-        confirm: If True, ask for confirmation
+        confirm: If True, ask for confirmation. Skipped for a supplied source,
+            which has nothing to confirm against.
 
     Returns:
-        The entered password
+        The password
     """
+    if _password_source is not None:
+        return _password_source
+
     password = getpass.getpass(prompt)
 
     if confirm:
@@ -290,6 +368,16 @@ def _prompt_password_with_validation(prompt: str = "Password: ") -> str:
     Returns:
         A valid password meeting strength requirements
     """
+    if _password_source is not None:
+        # A supplied source cannot be re-prompted, so a weak value is a hard
+        # failure rather than the interactive retry loop below.
+        is_strong, _ = check_password_strength(_password_source)
+        if not is_strong:
+            _print_error("Supplied password does not meet security requirements:")
+            _print_password_policy()
+            _exit_error(EXIT_INPUT_ERROR, "Supplied password is too weak.")
+        return _password_source
+
     while True:
         password = getpass.getpass(prompt)
         is_strong, _ = check_password_strength(password)
@@ -307,7 +395,9 @@ def _prompt_password_with_validation(prompt: str = "Password: ") -> str:
 
 
 def _prompt_master_password() -> str:
-    """Prompt for vault master password."""
+    """Obtain the vault master password, without prompting if one was supplied."""
+    if _master_password_source is not None:
+        return _master_password_source
     return getpass.getpass("Master password: ")
 
 
@@ -1702,6 +1792,23 @@ Run 'ssc <command> --help' for command-specific help.
         help="Disable colored output",
     )
     parser.add_argument(
+        "--password-file",
+        metavar="PATH",
+        help=(
+            "Read the data password from PATH instead of prompting "
+            "(or set SSC_PASSWORD; the flag wins). Must not be readable by "
+            "group or other."
+        ),
+    )
+    parser.add_argument(
+        "--master-password-file",
+        metavar="PATH",
+        help=(
+            "Read the vault master password from PATH instead of prompting "
+            "(or set SSC_MASTER_PASSWORD; the flag wins)"
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help=(
@@ -2212,6 +2319,7 @@ def main() -> NoReturn:
     _quiet_mode = args.quiet
     _no_color = args.no_color
     _debug_mode = args.debug or _env_flag_enabled("SSC_DEBUG")
+    _resolve_credential_sources(args)
 
     # No command specified
     if not args.command:

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -13,6 +13,7 @@ import argparse
 import getpass
 import hashlib
 import os
+import stat
 import sys
 import traceback
 from pathlib import Path
@@ -120,6 +121,10 @@ _debug_mode = False
 # from many places that have no access to the parsed arguments.
 _password_source: str | None = None
 _master_password_source: str | None = None
+# A master password being *set* is a different value from the one being used to
+# unlock, so it gets its own source. Reusing _master_password_source for both
+# would make `vault change-password` rotate to the password it already has.
+_new_master_password_source: str | None = None
 
 # A password file is read with the same bound v2 applies to a password before
 # derivation, so an oversized file is refused rather than fed to Argon2id.
@@ -284,20 +289,42 @@ def _read_password_file(path_str: str, *, role: str) -> str:
     One trailing line ending is removed — a file written with `echo` has one
     and the operator does not intend it as part of the password — using the
     same helper as the stdin path so both agree.
+
+    The checks are made against the open descriptor rather than the path, so
+    that replacing the final component between the check and the read cannot
+    substitute a different file: `O_NOFOLLOW` refuses a symlink put there,
+    and `fstat` re-checks type and permissions on what was actually opened.
+    This mirrors `v2/keyfile.py`'s loader, which guards the same race for the
+    other bearer secret this program reads.
     """
     path = Path(path_str).expanduser()
     try:
         reject_symlink_components(path)
-        if not path.is_file():
-            _exit_error(EXIT_FILE_ERROR, f"{role} file is not a regular file: {path}")
-        if os.name == "posix" and (path.stat().st_mode & 0o077):
-            _exit_error(
-                EXIT_FILE_ERROR,
-                f"{role} file is readable by group or other: {path}. "
-                "Restrict it with chmod 600.",
-            )
-        with open(path, "rb") as handle:
-            raw = handle.read(_MAX_PASSWORD_FILE_BYTES + 1)
+
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        try:
+            st = os.fstat(fd)
+            if not stat.S_ISREG(st.st_mode):
+                _exit_error(
+                    EXIT_FILE_ERROR, f"{role} file is not a regular file: {path}"
+                )
+            if os.name == "posix" and (st.st_mode & 0o077):
+                _exit_error(
+                    EXIT_FILE_ERROR,
+                    f"{role} file is readable by group or other: {path}. "
+                    "Restrict it with chmod 600.",
+                )
+            raw = b""
+            while len(raw) <= _MAX_PASSWORD_FILE_BYTES:
+                chunk = os.read(fd, _MAX_PASSWORD_FILE_BYTES + 1 - len(raw))
+                if not chunk:
+                    break
+                raw += chunk
+        finally:
+            os.close(fd)
     except OSError as error:
         detail = error.strerror or "could not be read"
         _exit_error(EXIT_FILE_ERROR, f"{role} file {detail}: {path}")
@@ -321,7 +348,7 @@ def _resolve_credential_sources(args: argparse.Namespace) -> None:
     more deliberate act, and it keeps a stale exported variable from quietly
     overriding what the command line asked for.
     """
-    global _password_source, _master_password_source
+    global _password_source, _master_password_source, _new_master_password_source
 
     if getattr(args, "password_file", None):
         _password_source = _read_password_file(args.password_file, role="Password")
@@ -334,6 +361,13 @@ def _resolve_credential_sources(args: argparse.Namespace) -> None:
         )
     elif os.environ.get("SSC_MASTER_PASSWORD"):
         _master_password_source = os.environ["SSC_MASTER_PASSWORD"]
+
+    if getattr(args, "new_master_password_file", None):
+        _new_master_password_source = _read_password_file(
+            args.new_master_password_file, role="New master password"
+        )
+    elif os.environ.get("SSC_NEW_MASTER_PASSWORD"):
+        _new_master_password_source = os.environ["SSC_NEW_MASTER_PASSWORD"]
 
 
 def _prompt_password(prompt: str = "Password: ", confirm: bool = False) -> str:
@@ -402,6 +436,40 @@ def _prompt_master_password() -> str:
     return getpass.getpass("Master password: ")
 
 
+def _prompt_master_password_to_set(
+    prompt: str, *, supplied: str | None, source_flag: str
+) -> str:
+    """Obtain a master password that is being *set*, not used to unlock.
+
+    Setting and unlocking are separate roles even though both are "the master
+    password": initialising a vault sets one, and `vault change-password` uses
+    the old one while setting a new one. Giving each role its own source is
+    what stops a single supplied value being read as both, which would rotate
+    a vault to the password it already had and report success.
+
+    A supplied value is strength-checked and fails hard rather than falling
+    back to a prompt, since a non-interactive caller cannot answer one.
+    """
+    if supplied is not None:
+        is_strong, _ = check_password_strength(supplied)
+        if not is_strong:
+            _print_error(f"Supplied master password ({source_flag}) is too weak:")
+            _print_password_policy()
+            _exit_error(EXIT_INPUT_ERROR, "Supplied master password is too weak.")
+        return supplied
+
+    while True:
+        password = getpass.getpass(prompt)
+        is_strong, _ = check_password_strength(password)
+        if is_strong:
+            if password != getpass.getpass("Confirm master password: "):
+                _print_error("Passwords do not match. Try again.")
+                continue
+            return password
+        _print_error("Master password does not meet security requirements:")
+        _print_password_policy()
+
+
 def _get_vault() -> PassphraseVault:
     """Get or initialize the vault."""
     vault = PassphraseVault()
@@ -415,7 +483,14 @@ def _get_vault() -> PassphraseVault:
 
         # Initialize vault
         print()
-        master = _prompt_password_with_validation("Set master password: ")
+        # The master source, not the data-password source: an operator who
+        # passes both files means the master one here, and initialising with
+        # the data password would leave the very next unlock failing.
+        master = _prompt_master_password_to_set(
+            "Set master password: ",
+            supplied=_master_password_source,
+            source_flag="--master-password-file / SSC_MASTER_PASSWORD",
+        )
         # Store a dummy entry to initialize, then delete it
         vault.store_passphrase("__init__", "init", master)
         vault.delete_passphrase("__init__", master)
@@ -1475,8 +1550,31 @@ def cmd_vault_change_password(args: argparse.Namespace) -> int:
     vault = PassphraseVault()
     _print_info("Enter current master password:")
     old_master = _prompt_master_password()
+
+    if _master_password_source is not None and _new_master_password_source is None:
+        # Falling back to an interactive prompt here would hang an unattended
+        # run, and reusing the supplied value would re-encrypt the vault with
+        # the password it already has while reporting a successful rotation.
+        _exit_error(
+            EXIT_INPUT_ERROR,
+            "The current master password was supplied, so the new one must be "
+            "too: pass --new-master-password-file PATH (or set "
+            "SSC_NEW_MASTER_PASSWORD). Reusing the current password would "
+            "report a rotation that did not happen.",
+        )
+
     _print_info("Enter new master password:")
-    new_master = _prompt_master_password()
+    new_master = _prompt_master_password_to_set(
+        "New master password: ",
+        supplied=_new_master_password_source,
+        source_flag="--new-master-password-file / SSC_NEW_MASTER_PASSWORD",
+    )
+    if new_master == old_master:
+        _exit_error(
+            EXIT_INPUT_ERROR,
+            "The new master password is the same as the current one; nothing "
+            "was changed.",
+        )
     service = V2VaultService(vault)
     try:
         service.change_master_password(old_master, new_master)
@@ -1810,6 +1908,14 @@ Run 'ssc <command> --help' for command-specific help.
         help=(
             "Read the vault master password from PATH instead of prompting "
             "(or set SSC_MASTER_PASSWORD; the flag wins)"
+        ),
+    )
+    parser.add_argument(
+        "--new-master-password-file",
+        metavar="PATH",
+        help=(
+            "Read the replacement master password for `vault change-password` "
+            "from PATH (or set SSC_NEW_MASTER_PASSWORD; the flag wins)"
         ),
     )
     parser.add_argument(

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -58,6 +58,7 @@ from .security import SecurityError
 from .timing_safe import check_password_strength
 from .utils import colorize, secure_overwrite
 from .v2.app import (
+    KeyDirectoryUnreadable,
     KeyFileNotFound,
     KeyFileUnreadable,
     KeyResolver,
@@ -884,6 +885,9 @@ def _resolve_v2_key_source(key_ref: str) -> KeyFileData:
         return KeyResolver().resolve(key_ref)
     except KeyFileUnreadable:
         _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
+    except KeyDirectoryUnreadable as error:
+        keys_dir = error.keys_dir
+        _exit_error(EXIT_FILE_ERROR, f"Could not search the keys directory: {keys_dir}")
     except KeyFileNotFound as error:
         # Hoisted out of the message expression so no exception name appears
         # in the sink call itself (tools/check_sensitive_output.py).

--- a/src/secure_string_cipher/v2/app.py
+++ b/src/secure_string_cipher/v2/app.py
@@ -1,0 +1,366 @@
+"""Reusable application logic for v2 credentials and managed-key policy.
+
+This layer exists so that more than one interface can perform v2
+encrypt/decrypt correctly. The same logic previously lived in
+``cli_args.py`` as private helpers that called ``sys.exit`` and ``getpass``
+directly, which made it unusable from anywhere else: a second surface
+calling the key-status check would have terminated the process instead of
+reporting an error, and would have blocked on a terminal prompt.
+
+Nothing here performs interactive input or exits the process. Callers supply
+credentials and receive either a value or a typed exception, and decide for
+themselves how to prompt, render and exit.
+
+Deliberately *not* included: obtaining a password. Where a password comes
+from — a prompt, a vault entry, a file, an environment variable — is an
+interface concern, so it stays with the caller. This module only says which
+credential an object requires and assembles one from parts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from secure_string_cipher.v2.encrypt import (
+    CombinedCredential,
+    KeyCredential,
+    PasswordCredential,
+    V2Credential,
+)
+from secure_string_cipher.v2.envelope import GrantType, V2Header
+from secure_string_cipher.v2.key_identity import KeyStatus
+from secure_string_cipher.v2.keyfile import KeyFileData, load_keyfile
+from secure_string_cipher.v2.vault_service import V2VaultService
+
+__all__ = [
+    "CredentialRequirement",
+    "GrantRequirement",
+    "KeyResolver",
+    "KeyStatusPolicy",
+    "KeyFileNotFound",
+    "KeyFileUnreadable",
+    "KeyStatusRejected",
+    "MalformedContainer",
+    "NoUsableGrant",
+    "V2AppError",
+    "VaultUnlockFailed",
+    "build_credential",
+    "default_keys_dir",
+    "header_from_armour",
+    "required_credential",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class V2AppError(Exception):
+    """Base class for a v2 application-layer failure."""
+
+
+class KeyFileNotFound(V2AppError):
+    """No `.ssckey` matched the supplied reference."""
+
+    def __init__(self, key_ref: str, keys_dir: Path):
+        self.key_ref = key_ref
+        self.keys_dir = keys_dir
+        super().__init__(
+            f"Key not found: provide a .ssckey path or a fingerprint/key-id "
+            f"present in {keys_dir}."
+        )
+
+
+class KeyFileUnreadable(V2AppError):
+    """A `.ssckey` was located but could not be loaded or validated."""
+
+    def __init__(self, path: Path, cause: BaseException):
+        self.path = path
+        self.cause = cause
+        super().__init__(f"Could not load key file: {path}")
+
+
+class KeyStatusRejected(V2AppError):
+    """The vault tracks this key and marks it unusable."""
+
+    def __init__(self, key_id: str, status: KeyStatus):
+        self.key_id = key_id
+        self.status = status
+        verb = (
+            "is revoked in" if status == KeyStatus.REVOKED else "has been destroyed in"
+        )
+        super().__init__(f"Key '{key_id}' {verb} this vault; refusing to use it.")
+
+
+class VaultUnlockFailed(V2AppError):
+    """The vault could not be opened to read key status."""
+
+    def __init__(self, cause: BaseException | None = None):
+        self.cause = cause
+        super().__init__("Could not unlock vault to check key status.")
+
+
+class NoUsableGrant(V2AppError):
+    """The header carries no grant this implementation can satisfy."""
+
+    def __init__(self) -> None:
+        super().__init__("No usable access grant found in V2 header.")
+
+
+class MalformedContainer(V2AppError):
+    """The input is not a well-formed v2 container."""
+
+    def __init__(self, cause: BaseException | None = None):
+        self.cause = cause
+        super().__init__("Not a valid V2 container.")
+
+
+# ---------------------------------------------------------------------------
+# What a container requires
+# ---------------------------------------------------------------------------
+
+
+class CredentialRequirement(Enum):
+    """The credential an object's single grant requires."""
+
+    PASSWORD = "password"  # pragma: allowlist secret - grant type name
+    MANAGED_KEY = "managed-key"
+    COMBINED = "combined-password-managed-key"
+
+
+@dataclass(frozen=True)
+class GrantRequirement:
+    """What a caller must supply to open a particular object.
+
+    `key_fingerprint` is the fingerprint the grant names, present whenever a
+    managed key is involved. A caller may resolve a different keyfile than
+    the named one (the CLI's `--key-file` does this), but the fingerprint
+    recorded in the grant is what the DEK was wrapped against.
+    """
+
+    requirement: CredentialRequirement
+    key_fingerprint: str | None = None
+
+    @property
+    def needs_password(self) -> bool:
+        return self.requirement in (
+            CredentialRequirement.PASSWORD,
+            CredentialRequirement.COMBINED,
+        )
+
+    @property
+    def needs_managed_key(self) -> bool:
+        return self.requirement in (
+            CredentialRequirement.MANAGED_KEY,
+            CredentialRequirement.COMBINED,
+        )
+
+
+def header_from_armour(armoured_text: str) -> V2Header:
+    """Extract and validate the protected header from an armoured message.
+
+    An armoured message carries its header as Base64'd canonical JSON rather
+    than the binary `SSC2` framing that `parse_header_stream` reads, so a
+    caller inspecting a text container before choosing a credential needs
+    this rather than the file path. Raises `MalformedContainer`, deliberately
+    without detail: the caller is about to decide whether to attempt
+    decryption, and a parse failure should not describe the input back.
+    """
+    import base64
+    import json
+
+    from secure_string_cipher.v2.header_parser import validate_v2_header
+    from secure_string_cipher.v2.message import unarmor_message
+    from secure_string_cipher.v2.vault_schema import _reject_duplicate_object_hook
+
+    try:
+        parsed = unarmor_message(armoured_text)
+        raw_bytes = base64.b64decode(parsed.header_b64, validate=True)
+        header_dict = json.loads(
+            raw_bytes.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_object_hook,
+        )
+        return validate_v2_header(header_dict, raw_bytes)
+    except Exception as error:
+        raise MalformedContainer(error) from error
+
+
+def required_credential(header: V2Header) -> GrantRequirement:
+    """Report what the header's grant requires. Pure; performs no I/O.
+
+    Raises `NoUsableGrant` when the grant type is not one this version can
+    satisfy. A v2 object always carries exactly one grant
+    (`AccessPolicy.SINGLE_GRANT`, enforced in envelope.py), so this inspects
+    that grant rather than searching for a satisfiable one among several.
+    """
+    grants = header.access.grants
+    if not grants:
+        raise NoUsableGrant
+    grant = grants[0]
+
+    if grant.type == GrantType.PASSWORD:
+        return GrantRequirement(CredentialRequirement.PASSWORD)
+
+    if grant.type == GrantType.MANAGED_KEY:
+        if not grant.key_fingerprint:
+            raise NoUsableGrant
+        return GrantRequirement(
+            CredentialRequirement.MANAGED_KEY, grant.key_fingerprint
+        )
+
+    if grant.type == GrantType.COMBINED_PASSWORD_MANAGED_KEY:
+        if not grant.key_fingerprint:
+            raise NoUsableGrant
+        return GrantRequirement(CredentialRequirement.COMBINED, grant.key_fingerprint)
+
+    raise NoUsableGrant
+
+
+# ---------------------------------------------------------------------------
+# Locating a managed key
+# ---------------------------------------------------------------------------
+
+
+def default_keys_dir() -> Path:
+    """The conventional location for managed keyfiles.
+
+    Resolved on each call rather than captured at import time, so that a
+    caller (or a test) which redirects the home directory is honoured.
+    """
+    return Path.home() / ".ssc" / "keys"
+
+
+class KeyResolver:
+    """Turns a key reference into validated keyfile data.
+
+    A reference is either a path to a `.ssckey` file or a fingerprint/key-id
+    belonging to a keyfile in `keys_dir`. Both encryption (`key:ID` sources)
+    and decryption (a grant's recorded fingerprint) use this, so the two
+    sides cannot drift apart in how they interpret a reference.
+    """
+
+    def __init__(self, keys_dir: Path | None = None):
+        self._keys_dir = keys_dir
+
+    @property
+    def keys_dir(self) -> Path:
+        return self._keys_dir if self._keys_dir is not None else default_keys_dir()
+
+    def resolve(self, key_ref: str) -> KeyFileData:
+        """Locate and load the keyfile `key_ref` names.
+
+        Raises `KeyFileUnreadable` if a path was clearly intended but could
+        not be loaded, and `KeyFileNotFound` if nothing matched.
+        """
+        candidate = Path(key_ref).expanduser()
+        if candidate.suffix == ".ssckey" or candidate.is_file():
+            try:
+                return load_keyfile(candidate)
+            except Exception as error:
+                raise KeyFileUnreadable(candidate, error) from error
+
+        keys_dir = self.keys_dir
+        if keys_dir.is_dir():
+            for child in sorted(keys_dir.iterdir()):
+                if child.suffix != ".ssckey":
+                    continue
+                try:
+                    key_data = load_keyfile(child)
+                except Exception:
+                    # A single unreadable or malformed keyfile in the
+                    # directory must not stop the search; the reference may
+                    # well name one of the others.
+                    continue
+                if key_ref in (key_data.fingerprint, key_data.key_id):
+                    return key_data
+
+        raise KeyFileNotFound(key_ref, keys_dir)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle policy
+# ---------------------------------------------------------------------------
+
+
+class KeyStatusPolicy:
+    """Refuses a managed key this vault marks revoked or destroyed.
+
+    Holding a `.ssckey` file is sufficient to use the key it contains, so
+    ordinary encrypt/decrypt reads the file straight off disk and never
+    consults the vault. That is inherent to a bearer secret, not a defect.
+    This check exists for the case where a caller *is* willing to open the
+    vault: it then refuses a key that vault records as revoked or destroyed.
+
+    A key the vault does not track cannot be checked and is allowed through.
+    `ARCHIVED` is bookkeeping only and never blocks use.
+    """
+
+    def __init__(self, service: V2VaultService):
+        self._service = service
+
+    def check(self, fingerprint: str, *, master_password: str) -> None:
+        """Raise if the vault marks `fingerprint` unusable.
+
+        Raises `VaultUnlockFailed` if the vault cannot be read, and
+        `KeyStatusRejected` if it records the key as revoked or destroyed.
+        """
+        try:
+            records = self._service.list_keys(master_password)
+        except Exception as error:
+            raise VaultUnlockFailed(error) from error
+
+        for record in records:
+            if record.fingerprint != fingerprint:
+                continue
+            if record.status in (KeyStatus.REVOKED, KeyStatus.DESTROYED):
+                raise KeyStatusRejected(record.id, record.status)
+            return
+
+
+# ---------------------------------------------------------------------------
+# Assembling a credential
+# ---------------------------------------------------------------------------
+
+
+def build_credential(
+    requirement: GrantRequirement,
+    *,
+    password: str | None = None,
+    key_data: KeyFileData | None = None,
+) -> V2Credential:
+    """Assemble the credential `requirement` describes from supplied parts.
+
+    The fingerprint recorded in the grant is used rather than the resolved
+    keyfile's own, so that a caller who pointed at a different file still
+    produces a credential naming what the DEK was wrapped against — and the
+    resulting mismatch surfaces as an authentication failure rather than
+    silently succeeding against the wrong identity.
+    """
+    if requirement.needs_password and password is None:
+        raise ValueError("this grant requires a password")
+    if requirement.needs_managed_key and key_data is None:
+        raise ValueError("this grant requires a managed key")
+
+    if requirement.requirement == CredentialRequirement.PASSWORD:
+        assert password is not None
+        return PasswordCredential(passphrase=password)
+
+    fingerprint = requirement.key_fingerprint
+    if not fingerprint:
+        raise NoUsableGrant
+    assert key_data is not None
+
+    if requirement.requirement == CredentialRequirement.MANAGED_KEY:
+        return KeyCredential(
+            key_fingerprint=fingerprint, managed_secret=key_data.secret_bytes
+        )
+
+    assert password is not None
+    return CombinedCredential(
+        passphrase=password,
+        key_fingerprint=fingerprint,
+        managed_secret=key_data.secret_bytes,
+    )

--- a/src/secure_string_cipher/v2/app.py
+++ b/src/secure_string_cipher/v2/app.py
@@ -37,6 +37,7 @@ from secure_string_cipher.v2.vault_service import V2VaultService
 __all__ = [
     "CredentialRequirement",
     "GrantRequirement",
+    "KeyDirectoryUnreadable",
     "KeyResolver",
     "KeyStatusPolicy",
     "KeyFileNotFound",
@@ -81,6 +82,20 @@ class KeyFileUnreadable(V2AppError):
         self.path = path
         self.cause = cause
         super().__init__(f"Could not load key file: {path}")
+
+
+class KeyDirectoryUnreadable(V2AppError):
+    """The keys directory exists but could not be searched.
+
+    Distinct from `KeyFileNotFound`: the reference may well have matched, but
+    the directory could not be read to find out. Reporting "not found" for an
+    unreadable directory would send the caller looking for the wrong problem.
+    """
+
+    def __init__(self, keys_dir: Path, cause: BaseException):
+        self.keys_dir = keys_dir
+        self.cause = cause
+        super().__init__(f"Could not search the keys directory: {keys_dir}")
 
 
 class KeyStatusRejected(V2AppError):
@@ -264,7 +279,16 @@ class KeyResolver:
 
         keys_dir = self.keys_dir
         if keys_dir.is_dir():
-            for child in sorted(keys_dir.iterdir()):
+            try:
+                children = sorted(keys_dir.iterdir())
+            except OSError as error:
+                # An unreadable directory, or one removed between the is_dir
+                # check and the listing, would otherwise raise a bare
+                # PermissionError/OSError straight past the V2AppError
+                # hierarchy this module advertises.
+                raise KeyDirectoryUnreadable(keys_dir, error) from error
+
+            for child in children:
                 if child.suffix != ".ssckey":
                     continue
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,7 @@ def reset_cli_output_flags() -> Generator[None]:
         "_debug_mode",
         "_password_source",
         "_master_password_source",
+        "_new_master_password_source",
     )
     saved = {name: getattr(cli_args, name) for name in names if hasattr(cli_args, name)}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,21 +138,28 @@ def reset_environment() -> Generator[None]:
 
 @pytest.fixture(autouse=True)
 def reset_cli_output_flags() -> Generator[None]:
-    """Restore cli_args' module-level output flags after each test.
+    """Restore cli_args' module-level flags after each test.
 
-    `_quiet_mode` and `_no_color` are process-wide globals that gate
-    `_print_info`/`_print_warning`. 39 tests in tests/unit/test_cli_args.py
-    set them to True without restoring, so every later test in the same
-    xdist worker saw silenced output — a latent order dependency that showed
-    up as `CaptureResult(out='', err='')` in the `ssc key` end-to-end tests
-    on whichever Python version happened to distribute them together.
+    `_quiet_mode` and `_no_color` gate `_print_info`/`_print_warning`, and 39
+    tests in tests/unit/test_cli_args.py set them to True without restoring.
+    Every later test in the same xdist worker then saw silenced output — a
+    latent order dependency that surfaced as `CaptureResult(out='', err='')`
+    in the `ssc key` end-to-end tests on whichever Python version happened to
+    distribute those files together.
 
-    Restoring here keeps that coupling from mattering, rather than relying on
-    the worker layout staying lucky.
+    The credential sources matter more: a leaked `_password_source` would
+    make a later test appear to succeed without prompting, hiding exactly the
+    behaviour it meant to exercise.
     """
     from secure_string_cipher import cli_args
 
-    names = ("_quiet_mode", "_no_color", "_debug_mode")
+    names = (
+        "_quiet_mode",
+        "_no_color",
+        "_debug_mode",
+        "_password_source",
+        "_master_password_source",
+    )
     saved = {name: getattr(cli_args, name) for name in names if hasattr(cli_args, name)}
 
     yield

--- a/tests/unit/test_cli_args_coverage.py
+++ b/tests/unit/test_cli_args_coverage.py
@@ -141,13 +141,19 @@ class TestVaultHelpers:
 
         assert _get_vault() is mock_vault
 
-    @patch("secure_string_cipher.cli_args._prompt_password_with_validation")
+    @patch("secure_string_cipher.cli_args._prompt_master_password_to_set")
     @patch("builtins.input", return_value="y")
     @patch("secure_string_cipher.cli_args.PassphraseVault")
     def test_get_vault_initializes_missing_vault(
         self, mock_vault_cls, mock_input, mock_prompt
     ):
-        """Should initialize a missing vault when the user accepts."""
+        """Should initialize a missing vault when the user accepts.
+
+        Patches the master-password prompt specifically: initialization used
+        to go through the *data* password prompt, so supplying both a data
+        and a master password built the vault with the wrong one and left the
+        next unlock failing.
+        """
         mock_vault = MagicMock()
         mock_vault.vault_exists.return_value = False
         mock_vault_cls.return_value = mock_vault

--- a/tests/unit/test_cli_credential_sources.py
+++ b/tests/unit/test_cli_credential_sources.py
@@ -1,0 +1,229 @@
+"""Tests for non-interactive credential sources.
+
+Before these existed there was no `--password`, `--password-file` or
+environment variable, so v2 password mode and v2 combined mode could not be
+scripted at all, and anything using the vault needed an interactive master
+password. Piping worked only through CPython's degraded `getpass` fallback,
+which emits a warning and has no equivalent on Windows.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from secure_string_cipher import cli_args
+
+STRONG = "Str0ngScriptPass!2026"  # pragma: allowlist secret
+WEAK = "short"  # pragma: allowlist secret
+OTHER = "Different!Pass2026"  # pragma: allowlist secret
+
+
+def _password_file(directory: Path, value: str, *, mode: int = 0o600) -> Path:
+    path = directory / "pw.txt"
+    path.write_text(value + "\n")
+    path.chmod(mode)
+    return path
+
+
+def _args(**overrides: object) -> object:
+    import argparse
+
+    defaults = {
+        "quiet": False,
+        "no_color": False,
+        "debug": False,
+        "password_file": None,
+        "master_password_file": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestPasswordFile:
+    def test_password_file_supplies_the_password_without_prompting(
+        self, tmp_path: Path
+    ) -> None:
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        # No getpass patching: if this prompted, the test would hang or raise.
+        assert cli_args._prompt_password() == STRONG
+
+    def test_one_trailing_newline_is_removed(self, tmp_path: Path) -> None:
+        """A file written with `echo` has a newline the operator did not intend."""
+        path = tmp_path / "pw.txt"
+        path.write_bytes(STRONG.encode() + b"\n")
+        path.chmod(0o600)
+        cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert cli_args._prompt_password() == STRONG
+
+    def test_a_file_without_a_trailing_newline_works(self, tmp_path: Path) -> None:
+        path = tmp_path / "pw.txt"
+        path.write_bytes(STRONG.encode())
+        path.chmod(0o600)
+        cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert cli_args._prompt_password() == STRONG
+
+    def test_confirmation_is_skipped_for_a_supplied_password(
+        self, tmp_path: Path
+    ) -> None:
+        """There is nothing to confirm a file against."""
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password(confirm=True) == STRONG
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission semantics")
+    def test_group_or_other_readable_file_is_refused(self, tmp_path: Path) -> None:
+        """A password file is a bearer secret, held to the same standard as
+        a .ssckey: refused rather than used with a warning."""
+        path = _password_file(tmp_path, STRONG, mode=0o644)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+    def test_empty_file_is_refused_rather_than_read_as_an_empty_password(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "empty.txt"
+        path.write_bytes(b"")
+        path.chmod(0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_newline_only_file_is_refused(self, tmp_path: Path) -> None:
+        path = tmp_path / "nl.txt"
+        path.write_bytes(b"\n")
+        path.chmod(0o600)
+        with pytest.raises(SystemExit):
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+
+    def test_missing_file_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(
+                _args(password_file=str(tmp_path / "absent.txt"))
+            )
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+    def test_a_directory_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit):
+            cli_args._resolve_credential_sources(_args(password_file=str(tmp_path)))
+
+    def test_non_utf8_file_is_refused(self, tmp_path: Path) -> None:
+        path = tmp_path / "bin.txt"
+        path.write_bytes(b"\xff\xfe not text")
+        path.chmod(0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_oversized_file_is_refused_before_reaching_the_kdf(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "big.txt"
+        path.write_bytes(b"A" * (cli_args._MAX_PASSWORD_FILE_BYTES + 10))
+        path.chmod(0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    @pytest.mark.skipif(os.name != "posix", reason="requires symlink support")
+    def test_a_symlinked_password_file_is_refused(self, tmp_path: Path) -> None:
+        real = _password_file(tmp_path, STRONG)
+        link = tmp_path / "link.txt"
+        link.symlink_to(real)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(link)))
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+
+class TestEnvironmentVariables:
+    def test_ssc_password_supplies_the_password(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+        assert cli_args._prompt_password() == STRONG
+
+    def test_ssc_master_password_supplies_the_master_password(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+        assert cli_args._prompt_master_password() == STRONG
+
+    def test_an_empty_variable_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_PASSWORD", "")
+        cli_args._resolve_credential_sources(_args())
+        assert cli_args._password_source is None
+
+    def test_the_flag_wins_over_the_variable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Naming a file is the more deliberate act, and it stops a stale
+        exported variable quietly overriding the command line."""
+        monkeypatch.setenv("SSC_PASSWORD", OTHER)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password() == STRONG
+
+    def test_the_two_roles_are_independent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A data password and a vault master password are different secrets."""
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", OTHER)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password() == STRONG
+        assert cli_args._prompt_master_password() == OTHER
+
+
+class TestStrengthValidationStillApplies:
+    def test_a_weak_supplied_password_is_refused_not_retried(
+        self, tmp_path: Path
+    ) -> None:
+        """The interactive path loops until the password is strong enough.
+
+        A supplied source cannot be re-prompted, so it must fail rather than
+        loop forever.
+        """
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, WEAK)))
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._prompt_password_with_validation()
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_a_strong_supplied_password_is_accepted(self, tmp_path: Path) -> None:
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password_with_validation() == STRONG
+
+
+class TestParser:
+    def test_both_flags_are_accepted_and_default_to_none(self) -> None:
+        parser = cli_args.create_parser()
+        args = parser.parse_args(["encrypt", "-t", "x"])
+        assert args.password_file is None
+        assert args.master_password_file is None
+
+        args = parser.parse_args(
+            [
+                "--password-file",
+                "/p",
+                "--master-password-file",
+                "/m",
+                "encrypt",
+                "-t",
+                "x",
+            ]
+        )
+        assert args.password_file == "/p"
+        assert args.master_password_file == "/m"

--- a/tests/unit/test_cli_credential_sources.py
+++ b/tests/unit/test_cli_credential_sources.py
@@ -227,3 +227,114 @@ class TestParser:
         )
         assert args.password_file == "/p"
         assert args.master_password_file == "/m"
+
+
+class TestTheTwoMasterPasswordRolesAreDistinct:
+    """Setting a master password and using one are different roles.
+
+    A single supplied value read as both would let `vault change-password`
+    re-encrypt the vault with the password it already has and report a
+    successful rotation — an operator rotating a compromised password would
+    believe it had been replaced.
+    """
+
+    def test_change_password_refuses_to_reuse_the_supplied_current_password(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import argparse
+
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args.cmd_vault_change_password(argparse.Namespace())
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_the_new_password_has_its_own_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        monkeypatch.setenv("SSC_NEW_MASTER_PASSWORD", OTHER)
+        cli_args._resolve_credential_sources(_args())
+
+        assert cli_args._prompt_master_password() == STRONG
+        assert (
+            cli_args._prompt_master_password_to_set(
+                "unused: ",
+                supplied=cli_args._new_master_password_source,
+                source_flag="",
+            )
+            == OTHER
+        )
+
+    def test_a_weak_password_being_set_fails_rather_than_prompting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_NEW_MASTER_PASSWORD", WEAK)
+        cli_args._resolve_credential_sources(_args())
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._prompt_master_password_to_set(
+                "unused: ",
+                supplied=cli_args._new_master_password_source,
+                source_flag="SSC_NEW_MASTER_PASSWORD",
+            )
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_vault_initialisation_uses_the_master_source_not_the_data_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With both files supplied, initialising from the data password
+        would leave the very next unlock failing against the master one."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("SSC_PASSWORD", OTHER)
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+        monkeypatch.setattr("builtins.input", lambda: "y")
+
+        vault = cli_args._get_vault()
+        assert vault.vault_exists()
+        # Proof of which password the vault was built with: the master one
+        # opens it, and a store/retrieve round-trip completes.
+        vault.store_passphrase("label", "value", STRONG)
+        assert vault.retrieve_passphrase("label", STRONG) == "value"
+
+
+class TestTheFileIsCheckedOnTheDescriptor:
+    """The permission and type checks must apply to what was opened.
+
+    Checking the path and then opening it leaves a window in which another
+    local process can replace the final component, so the checks would
+    describe the old inode while the read consumes a substituted one. The
+    race is not deterministically reproducible from a test, so these assert
+    the mechanism that closes it instead of staging a fake reproduction.
+    """
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="POSIX-only flag")
+    def test_the_file_is_opened_with_o_nofollow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded: list[int] = []
+        real_open = os.open
+
+        def spy(path: object, flags: int, *args: object, **kwargs: object) -> int:
+            recorded.append(flags)
+            return real_open(path, flags, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "open", spy)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert recorded, "the password file was not opened through os.open"
+        assert all(flags & os.O_NOFOLLOW for flags in recorded)
+
+    @pytest.mark.skipif(os.name != "posix", reason="requires mkfifo")
+    def test_a_fifo_is_refused_by_the_descriptor_type_check(
+        self, tmp_path: Path
+    ) -> None:
+        """A named pipe is not a file to read a password from, and reading
+        one would block or return an attacker-fed value."""
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo, 0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(fifo)))
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR

--- a/tests/unit/test_v2_app_layer.py
+++ b/tests/unit/test_v2_app_layer.py
@@ -7,6 +7,7 @@ reintroduces `getpass` or `sys.exit` into this module, the tests that drive
 it headlessly are what will notice.
 """
 
+import os
 import secrets
 from pathlib import Path
 
@@ -15,6 +16,7 @@ import pytest
 from secure_string_cipher.v2.app import (
     CredentialRequirement,
     GrantRequirement,
+    KeyDirectoryUnreadable,
     KeyFileNotFound,
     KeyFileUnreadable,
     KeyResolver,
@@ -132,6 +134,29 @@ class TestKeyResolver:
         (tmp_path / "broken.ssckey").write_text("garbage\n")
         _, good = _write_keyfile(tmp_path, "good-key")
         assert KeyResolver(tmp_path).resolve("good-key").fingerprint == good.fingerprint
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission semantics")
+    def test_unreadable_keys_directory_raises_a_typed_error(
+        self, tmp_path: Path
+    ) -> None:
+        """An unreadable directory must not raise a bare PermissionError.
+
+        The layer advertises that every failure is a V2AppError; a raw
+        filesystem exception escaping past that breaks the contract for any
+        caller writing `except V2AppError`. It is also reported distinctly
+        from "not found", since the reference may well have matched.
+        """
+        keys_dir = tmp_path / "keys"
+        keys_dir.mkdir()
+        os.chmod(keys_dir, 0o000)
+        try:
+            with pytest.raises(KeyDirectoryUnreadable) as excinfo:
+                KeyResolver(keys_dir).resolve("anything")
+            assert isinstance(excinfo.value, V2AppError)
+            assert isinstance(excinfo.value.cause, OSError)
+            assert excinfo.value.keys_dir == keys_dir
+        finally:
+            os.chmod(keys_dir, 0o700)
 
     def test_missing_keys_directory_is_not_an_error_in_itself(
         self, tmp_path: Path
@@ -266,6 +291,7 @@ class TestLayerIsHeadless:
         """A caller can handle the whole layer without enumerating classes."""
         for error in (
             KeyFileNotFound("x", Path("/k")),
+            KeyDirectoryUnreadable(Path("/k"), OSError("denied")),
             KeyFileUnreadable(Path("/k/x.ssckey"), OSError("boom")),
             KeyStatusRejected("k", KeyStatus.REVOKED),
             VaultUnlockFailed(),

--- a/tests/unit/test_v2_app_layer.py
+++ b/tests/unit/test_v2_app_layer.py
@@ -1,0 +1,295 @@
+"""Tests for the reusable v2 application layer.
+
+The defining property of this layer is what it does *not* do: no prompting,
+no process exit. Everything here therefore runs with no TTY attached and
+asserts on returned values or raised exceptions. If a future change
+reintroduces `getpass` or `sys.exit` into this module, the tests that drive
+it headlessly are what will notice.
+"""
+
+import secrets
+from pathlib import Path
+
+import pytest
+
+from secure_string_cipher.v2.app import (
+    CredentialRequirement,
+    GrantRequirement,
+    KeyFileNotFound,
+    KeyFileUnreadable,
+    KeyResolver,
+    KeyStatusPolicy,
+    KeyStatusRejected,
+    NoUsableGrant,
+    V2AppError,
+    VaultUnlockFailed,
+    build_credential,
+    default_keys_dir,
+    header_from_armour,
+    required_credential,
+)
+from secure_string_cipher.v2.encrypt import (
+    CombinedCredential,
+    KeyCredential,
+    PasswordCredential,
+    encrypt_v2_text,
+)
+from secure_string_cipher.v2.envelope import V2Header
+from secure_string_cipher.v2.key_identity import KeyStatus, compute_fingerprint
+from secure_string_cipher.v2.keyfile import KeyFileData, save_keyfile
+
+PASSWORD = "Str0ngPassphrase!2026"  # pragma: allowlist secret
+# Stub master passwords. Named constants rather than inline literals so the
+# allowlist pragma cannot be detached from them by the formatter.
+MASTER = "stub-master"  # pragma: allowlist secret
+WRONG_MASTER = "stub-wrong"  # pragma: allowlist secret
+
+
+def _write_keyfile(directory: Path, key_id: str) -> tuple[Path, KeyFileData]:
+    secret = secrets.token_bytes(32)
+    data = KeyFileData(
+        version=1,
+        key_id=key_id,
+        key_type="symmetric-key",
+        kdf="hkdf-sha256",
+        fingerprint=compute_fingerprint(secret),
+        created_at="2026-09-12T00:00:00Z",
+        secret_bytes=secret,
+    )
+    path = directory / f"{key_id}.ssckey"
+    save_keyfile(data, path)
+    return path, data
+
+
+def _header_for(credential) -> V2Header:
+    """Seal a real object and hand back its parsed header."""
+    return header_from_armour(encrypt_v2_text("probe", credential))
+
+
+class TestRequiredCredential:
+    """`required_credential` is pure: it inspects a header and nothing else."""
+
+    def test_password_grant(self) -> None:
+        header = _header_for(PasswordCredential(PASSWORD))
+        req = required_credential(header)
+        assert req.requirement is CredentialRequirement.PASSWORD
+        assert req.needs_password and not req.needs_managed_key
+        assert req.key_fingerprint is None
+
+    def test_managed_key_grant(self, tmp_path: Path) -> None:
+        _, data = _write_keyfile(tmp_path, "probe-key")
+        header = _header_for(KeyCredential(data.fingerprint, data.secret_bytes))
+        req = required_credential(header)
+        assert req.requirement is CredentialRequirement.MANAGED_KEY
+        assert req.needs_managed_key and not req.needs_password
+        assert req.key_fingerprint == data.fingerprint
+
+    def test_combined_grant(self, tmp_path: Path) -> None:
+        _, data = _write_keyfile(tmp_path, "probe-key")
+        header = _header_for(
+            CombinedCredential(PASSWORD, data.fingerprint, data.secret_bytes)
+        )
+        req = required_credential(header)
+        assert req.requirement is CredentialRequirement.COMBINED
+        assert req.needs_password and req.needs_managed_key
+        assert req.key_fingerprint == data.fingerprint
+
+
+class TestKeyResolver:
+    def test_resolves_an_explicit_path(self, tmp_path: Path) -> None:
+        path, data = _write_keyfile(tmp_path, "by-path")
+        assert KeyResolver().resolve(str(path)).fingerprint == data.fingerprint
+
+    def test_resolves_by_key_id_from_the_keys_directory(self, tmp_path: Path) -> None:
+        _, data = _write_keyfile(tmp_path, "by-id")
+        assert KeyResolver(tmp_path).resolve("by-id").fingerprint == data.fingerprint
+
+    def test_resolves_by_fingerprint_from_the_keys_directory(
+        self, tmp_path: Path
+    ) -> None:
+        _, data = _write_keyfile(tmp_path, "by-fingerprint")
+        resolved = KeyResolver(tmp_path).resolve(data.fingerprint)
+        assert resolved.key_id == "by-fingerprint"
+
+    def test_unknown_reference_raises_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(KeyFileNotFound) as excinfo:
+            KeyResolver(tmp_path).resolve("no-such-key")
+        assert excinfo.value.key_ref == "no-such-key"
+        assert str(tmp_path) in str(excinfo.value)
+
+    def test_corrupt_keyfile_at_an_explicit_path_raises_unreadable(
+        self, tmp_path: Path
+    ) -> None:
+        bad = tmp_path / "broken.ssckey"
+        bad.write_text("not a keyfile at all\n")
+        with pytest.raises(KeyFileUnreadable) as excinfo:
+            KeyResolver(tmp_path).resolve(str(bad))
+        assert excinfo.value.path == bad
+        assert excinfo.value.cause is not None
+
+    def test_one_corrupt_keyfile_does_not_hide_the_others(self, tmp_path: Path) -> None:
+        """A malformed neighbour must not abort the directory search."""
+        (tmp_path / "broken.ssckey").write_text("garbage\n")
+        _, good = _write_keyfile(tmp_path, "good-key")
+        assert KeyResolver(tmp_path).resolve("good-key").fingerprint == good.fingerprint
+
+    def test_missing_keys_directory_is_not_an_error_in_itself(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(KeyFileNotFound):
+            KeyResolver(tmp_path / "absent").resolve("anything")
+
+    def test_default_keys_directory_follows_the_current_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolved per call, not captured at import time."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        assert default_keys_dir() == tmp_path / ".ssc" / "keys"
+        assert KeyResolver().keys_dir == tmp_path / ".ssc" / "keys"
+
+
+class _StubService:
+    """Stands in for V2VaultService without needing a real vault."""
+
+    def __init__(self, records=None, error: Exception | None = None):
+        self._records = records or []
+        self._error = error
+        self.seen_password: str | None = None
+
+    def list_keys(self, master_password: str):
+        self.seen_password = master_password
+        if self._error is not None:
+            raise self._error
+        return self._records
+
+
+class _Record:
+    def __init__(self, key_id: str, fingerprint: str, status: KeyStatus):
+        self.id = key_id
+        self.fingerprint = fingerprint
+        self.status = status
+
+
+class TestKeyStatusPolicy:
+    FP = "ssc-k1-" + "A" * 52
+
+    def test_active_key_passes(self) -> None:
+        service = _StubService([_Record("k", self.FP, KeyStatus.ACTIVE)])
+        KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+        assert service.seen_password == MASTER, (
+            "the password must be injected, not read"
+        )
+
+    def test_archived_key_passes(self) -> None:
+        """Archive is bookkeeping only; it never blocks use."""
+        service = _StubService([_Record("k", self.FP, KeyStatus.ARCHIVED)])
+        KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+
+    @pytest.mark.parametrize("status", [KeyStatus.REVOKED, KeyStatus.DESTROYED])
+    def test_revoked_or_destroyed_key_is_rejected(self, status: KeyStatus) -> None:
+        service = _StubService([_Record("laptop", self.FP, status)])
+        with pytest.raises(KeyStatusRejected) as excinfo:
+            KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+        assert excinfo.value.key_id == "laptop"
+        assert excinfo.value.status is status
+        assert "laptop" in str(excinfo.value)
+
+    def test_untracked_key_is_allowed_through(self) -> None:
+        """A bare .ssckey this vault never registered cannot be judged."""
+        other = "ssc-k1-" + "B" * 52
+        service = _StubService([_Record("k", other, KeyStatus.REVOKED)])
+        KeyStatusPolicy(service).check(self.FP, master_password=MASTER)
+
+    def test_unopenable_vault_raises_rather_than_silently_allowing(self) -> None:
+        service = _StubService(error=RuntimeError("bad master password"))
+        with pytest.raises(VaultUnlockFailed) as excinfo:
+            KeyStatusPolicy(service).check(self.FP, master_password=WRONG_MASTER)
+        assert isinstance(excinfo.value.cause, RuntimeError)
+
+
+class TestBuildCredential:
+    FP = "ssc-k1-" + "C" * 52
+
+    def _key_data(self) -> KeyFileData:
+        secret = secrets.token_bytes(32)
+        return KeyFileData(
+            version=1,
+            key_id="k",
+            key_type="symmetric-key",
+            kdf="hkdf-sha256",
+            fingerprint=compute_fingerprint(secret),
+            created_at="2026-09-12T00:00:00Z",
+            secret_bytes=secret,
+        )
+
+    def test_builds_each_credential_type(self) -> None:
+        data = self._key_data()
+        password_only = build_credential(
+            GrantRequirement(CredentialRequirement.PASSWORD), password=PASSWORD
+        )
+        assert isinstance(password_only, PasswordCredential)
+
+        key_only = build_credential(
+            GrantRequirement(CredentialRequirement.MANAGED_KEY, self.FP), key_data=data
+        )
+        assert isinstance(key_only, KeyCredential)
+
+        combined = build_credential(
+            GrantRequirement(CredentialRequirement.COMBINED, self.FP),
+            password=PASSWORD,
+            key_data=data,
+        )
+        assert isinstance(combined, CombinedCredential)
+
+    def test_uses_the_grant_fingerprint_not_the_keyfile_one(self) -> None:
+        """A caller may point at a different file; the grant still names the
+        identity the DEK was wrapped against, so a mismatch must surface as an
+        authentication failure rather than silently succeeding."""
+        data = self._key_data()
+        credential = build_credential(
+            GrantRequirement(CredentialRequirement.MANAGED_KEY, self.FP), key_data=data
+        )
+        assert credential.key_fingerprint == self.FP != data.fingerprint
+
+    def test_missing_parts_are_refused(self) -> None:
+        with pytest.raises(ValueError, match="requires a password"):
+            build_credential(GrantRequirement(CredentialRequirement.PASSWORD))
+        with pytest.raises(ValueError, match="requires a managed key"):
+            build_credential(
+                GrantRequirement(CredentialRequirement.MANAGED_KEY, self.FP)
+            )
+
+
+class TestLayerIsHeadless:
+    def test_every_app_error_is_catchable_as_one_type(self) -> None:
+        """A caller can handle the whole layer without enumerating classes."""
+        for error in (
+            KeyFileNotFound("x", Path("/k")),
+            KeyFileUnreadable(Path("/k/x.ssckey"), OSError("boom")),
+            KeyStatusRejected("k", KeyStatus.REVOKED),
+            VaultUnlockFailed(),
+            NoUsableGrant(),
+        ):
+            assert isinstance(error, V2AppError)
+            assert str(error), "each error must carry a renderable message"
+
+    def test_a_full_headless_round_trip(self, tmp_path: Path) -> None:
+        """Resolve, check status and build a credential with no TTY involved.
+
+        This is the path a TUI or library caller would take, and the one that
+        previously could not exist because the equivalent CLI helpers called
+        sys.exit and getpass.
+        """
+        _, data = _write_keyfile(tmp_path, "headless")
+        header = _header_for(KeyCredential(data.fingerprint, data.secret_bytes))
+
+        requirement = required_credential(header)
+        resolved = KeyResolver(tmp_path).resolve(requirement.key_fingerprint or "")
+        KeyStatusPolicy(
+            _StubService([_Record("headless", data.fingerprint, KeyStatus.ACTIVE)])
+        ).check(data.fingerprint, master_password=MASTER)
+        credential = build_credential(requirement, key_data=resolved)
+
+        assert isinstance(credential, KeyCredential)
+        assert credential.key_fingerprint == data.fingerprint


### PR DESCRIPTION
Closes **#94**. **Stacked on #118** — base is `feat/v2-app-layer`, since both touch `cli_args.py`. GitHub will retarget this to `main` once #118 merges.

## Why now, and why before #95

There was no non-interactive credential source at all. The only options were `--vault` (which itself needs an interactive master password) and `--key-file` (v1 only). So:

- **v2 password mode** could not be scripted
- **v2 combined mode** could not be scripted
- every vault or key command required a person at a terminal

Piping worked only through CPython's degraded `getpass` fallback, which prints `GetPassWarning: Can not control echo` and has no Windows equivalent.

This has to land **before #95**. You chose default-on key-status enforcement, which introduces a master-password prompt into `ssc encrypt --with key:X` — currently the one scriptable v2 path. Without an escape hatch first, #95 would break automation the moment it lands.

## Two roles, deliberately not one flag

```
--password-file / SSC_PASSWORD                the data password
--master-password-file / SSC_MASTER_PASSWORD  the vault master password
```

Kept separate rather than overloading a single flag — we have just spent effort *removing* an overload from `--vault` (#95), so adding a new one would be a poor trade.

**The flag wins over the variable.** Naming a file is the more deliberate act, and it stops a stale exported value quietly overriding the command line. Verified cryptographically rather than by inspection: a token encrypted with the file's password fails to decrypt when only the variable is set, and succeeds with the file.

## Safety

A password file is the same kind of secret as a `.ssckey`, so it is held to the same standard:

| condition | result |
|---|---|
| group/other-readable (POSIX) | **refused** — `chmod 600` advised in the message |
| reached through a symlink | refused |
| not a regular file / missing / a directory | refused |
| empty or newline-only | refused, rather than read as an empty password |
| larger than 65536 bytes | refused before reaching Argon2id (the same bound v2 applies) |
| not valid UTF-8 | refused |

One trailing line ending is removed via the same helper the stdin path uses, so the two agree — a file written with `echo` has one and the operator does not intend it.

Confirmation is skipped for a supplied password (nothing to confirm against). Where a *new* password is being set, strength validation still applies but **fails rather than looping**, since a file cannot be re-prompted.

The README notes that a file is preferable to a variable: on some systems a process's environment is readable by other processes of the same user, and variables are easily captured in shell history and CI logs.

## Verification

The three previously-impossible flows, confirmed by hand end to end:

```
ssc --password-file pw.txt encrypt -f doc.txt --with password           -> 0
SSC_PASSWORD=... ssc encrypt -f doc.txt --with password                 -> 0
ssc --password-file pw.txt encrypt -f doc.txt \
    --with password --with key:ci --require all                         -> 0
```

Plus every rejection above, checked live. 20 new tests; full suite **1673 passing**; `ruff`, `mypy src` and the sensitive-output guard clean.

`tests/conftest.py`'s autouse fixture now restores the new globals: a leaked `_password_source` would make a later test appear to succeed without prompting, hiding the behaviour it meant to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)