### PR TITLE
feat(cli): enforce managed-key status by default

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "README.md",
         "hashed_secret": "eeb7f851dfdec7a9f083802e5454d0c98fa9d616",
         "is_verified": false,
-        "line_number": 446
+        "line_number": 471
       }
     ],
     "src/secure_string_cipher/audit_log.py": [
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 632
+        "line_number": 635
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T22:31:55Z"
+  "generated_at": "2026-09-12T22:37:40Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@
 
 ### Changed
 
+- **Managed-key status is now enforced by default, not only with `--vault`.**
+  `ssc key revoke` / `destroy` previously changed a vault record that
+  encrypt and decrypt did not read unless the operator also passed
+  `--vault LABEL`, so revocation did nothing for anyone who did not opt in
+  — which is to say, for the default path. The check now runs whenever a
+  vault exists on this machine: a key that vault records as `revoked` or
+  `destroyed` is refused. A key the vault does not track cannot be checked
+  and passes through, and `archived` still never blocks use.
+  `--no-enforce-key-status` skips the check for an unreachable vault or a
+  deliberately offline run. **This can turn a previously-succeeding
+  command into exit 2**, and, because reading status needs the master
+  password, it can introduce a prompt where there was none — supply it
+  with `--master-password-file` / `SSC_MASTER_PASSWORD`, or skip the check.
+  With no vault present, nothing changes: no check, no prompt. The control
+  remains advisory rather than cryptographic — whoever holds a `.ssckey`
+  holds the key it contains — so it raises the cost of using a revoked key
+  instead of making it impossible; see `docs/THREAT_MODEL.md` §5.5.
 - **CLI failures now map to the documented exit codes, and say what went
   wrong.** `main()` previously caught every exception with a bare
   `except Exception` and reported `Error: Command failed.` with

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ records are clearly separated in the documentation archive.
   create/import/export/show/list/rename are functional — see
   [ROADMAP.md](ROADMAP.md) for the deferred `ssc start` interactive-menu
   parity item. `archive`/`revoke`/`destroy` change the vault record's
-  status; by default encryption/decryption don't check it (a key file you
-  hold still works, by design), but passing `--vault LABEL` alongside a
-  key source now rejects a revoked or destroyed key that this vault tracks
+  status, and encryption/decryption enforce it by default: when a vault
+  exists, a key it records as revoked or destroyed is refused. Pass
+  `--no-enforce-key-status` to skip the check when the vault is
+  unreachable — a key file you hold can always be used offline, which is
+  inherent to a bearer secret
 - **OS Keychain integration** – store vault in macOS Keychain, Windows Credential Vault, or Linux Secret Service
 - **Hidden password input** – passwords hidden in interactive terminals, visible for scripts/tests
 - **Inline passphrase generation** – type `/gen` at an interactive
@@ -157,6 +159,29 @@ written with `echo` has one.
 Prefer a file over an environment variable where you can: on some systems a
 process's environment is readable by other processes owned by the same user,
 and variables are easily captured in shell history and CI logs.
+
+#### Managed-key status enforcement
+
+When a vault exists on this machine, `ssc encrypt --with key:...` and
+`ssc decrypt` of a managed-key object check that vault's record for the key
+and refuse one marked `revoked` or `destroyed`. A key the vault does not
+track cannot be checked and is allowed through; `archived` is bookkeeping
+and never blocks use.
+
+The check needs the vault master password, so supply it from a file or the
+environment (above) in automation. Two cases need no password at all: no
+vault on this machine, and `--no-enforce-key-status`.
+
+```bash
+# Skip the check — for an unreachable vault, or a deliberately offline run
+# (a global flag, so it goes before the subcommand, like --password-file)
+ssc --no-enforce-key-status encrypt -f document.pdf --with key:my-key
+```
+
+Skipping is not a way to un-revoke a key: holding a `.ssckey` file is
+holding the key it contains, so an offline copy always works. The check
+raises the cost of a revoked key staying in use where the vault *is*
+reachable; it is not a cryptographic revocation.
 
 ```bash
 # Encrypt text

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,17 +90,19 @@ Required v2.0.0 release gate — all items below are now closed as of
   verified directly, not just via successful decryption. Necessarily
   decrypt-only (frame nonces/salts are random every encryption by design).
 - **Key status (`archive`/`revoke`/`destroy`) enforcement at encrypt/decrypt
-  time.** By default `cli_args.py::_resolve_v2_key_source` still resolves
-  `.ssckey` files directly off disk without consulting vault status — a
-  revoked or destroyed key you still hold keeps working, which is inherent
-  to holding the file, not a bug — but passing `--vault LABEL` alongside a
-  key source now unlocks the vault and rejects a `revoked`/`destroyed` key
-  that this vault tracks.
+  time.** Enforced by default: whenever a vault exists on this machine,
+  `ssc encrypt --with key:ID` and `ssc decrypt` read that key's vault
+  record and refuse a `revoked`/`destroyed` one. A key the vault does not
+  track cannot be checked and passes through; `archive` never blocks use.
+  `--no-enforce-key-status` skips the check for an unreachable vault or a
+  deliberately offline run — the holder of a `.ssckey` can always use the
+  key it contains, which is inherent to a bearer secret, so the check
+  raises the cost of using a revoked key rather than making it impossible.
 - **CLI end-to-end test coverage for the full `ssc key` subcommand group.**
   `create`/`import`/`show`/`export`/`list`/`rename`/`archive`/`revoke`/
   `destroy` are each now exercised as real `cmd_key_*` calls against a
   hermetic, file-backed vault (`tests/unit/test_v2_key_cli_e2e.py`),
-  including the revoke/destroy interaction with `--vault` enforcement
+  including the revoke/destroy interaction with status enforcement
   above — not just argument parsing or the underlying `V2VaultService`
   methods in isolation.
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -27,11 +27,12 @@ cannot be opened by more than one distinct credential.
    by decrypt via its magic bytes (independent of the file extension).
 2. **Managed Keys**: `.ssckey` files hold a random 256-bit secret. `ssc key
    create`, `import`, `show`, `export`, `list`, and `rename` all work end to
-   end. Key status changes (`archive`/`revoke`/`destroy`) are always vault
-   bookkeeping; by default they don't prevent a `.ssckey` file you still
-   hold from being used, but `ssc encrypt`/`ssc decrypt --vault LABEL`
-   alongside a key source now enforces `revoke`/`destroy` for a key that
-   vault tracks — see the Key Management section below.
+   end. Key status changes (`archive`/`revoke`/`destroy`) are vault
+   bookkeeping, and `ssc encrypt`/`ssc decrypt` now enforce
+   `revoke`/`destroy` by default for any key a vault on this machine
+   tracks. `--no-enforce-key-status` skips the check; a `.ssckey` file you
+   hold can always be used offline — see the Key Management section
+   below.
 3. **Combined authentication**: You can encrypt a single file so that its one
    grant requires *both* a password and a key. There is no "either one"
    (any-of) mode — `--require any` with more than one `--with` source is
@@ -114,27 +115,32 @@ ssc key create <id> (--external-file PATH | --vault-copy)
                                     # works — exactly one storage target is
                                     #   required; omitting both exits with
                                     #   an input error
-ssc key archive <id>               # flips a vault status field
-ssc key revoke <id>                # flips a vault status field; enforced at
-ssc key destroy <id>               #   encrypt/decrypt only if you also pass
-                                    #   --vault LABEL (see below) — without
-                                    #   it, a .ssckey file you still hold
-                                    #   keeps working, by design
+ssc key archive <id>               # flips a vault status field; never
+                                    #   blocks use
+ssc key revoke <id>                # flips a vault status field, and is
+ssc key destroy <id>               #   enforced at encrypt/decrypt by
+                                    #   default whenever a vault exists
+                                    #   here (see below)
 ```
 
 Revoking or destroying a key you tracked in this vault:
 
 ```bash
 ssc key revoke laptop-backup
-ssc encrypt file.txt --with key:laptop-backup --vault anything   # now rejected
-ssc encrypt file.txt --with key:laptop-backup                    # still works
-                                                                   #   (offline, no vault check)
+ssc encrypt file.txt --with key:laptop-backup   # rejected
+
+# --no-enforce-key-status is a global flag, so it precedes the subcommand
+ssc --no-enforce-key-status encrypt file.txt --with key:laptop-backup
 ```
 
-Note there is currently no CLI end-to-end test coverage for the create/
-import/show/export/list/rename/archive path of this command group (the
-key-status-enforcement path above does have coverage) — see
-[ROADMAP.md](../ROADMAP.md).
+The check reads the vault, so it needs the master password; supply it with
+`--master-password-file` or `SSC_MASTER_PASSWORD` in automation. With no
+vault on this machine there is nothing to check and nothing to prompt for,
+so scripted use of a bare `.ssckey` is unaffected.
+
+`--no-enforce-key-status` does not un-revoke anything. Whoever holds the
+`.ssckey` file holds the key, so an offline copy always works; the check
+stops a revoked key being used where the vault *is* reachable.
 
 ## FAQ
 

--- a/docs/SSC2_PROTOCOL_SPECIFICATION.md
+++ b/docs/SSC2_PROTOCOL_SPECIFICATION.md
@@ -556,9 +556,11 @@ keyfiles with owner-only permissions where the platform supports it.
 - **Key-lifecycle enforcement policy.** What a client does when a key is
   marked `archived`/`revoked`/`destroyed` (whether it blocks use, requires
   an extra flag, etc.) is local application policy, not a wire-format
-  concern — and is currently opt-in in the reference implementation
-  (enforced only when a vault is explicitly consulted via `--vault`),
-  not a property every implementation of this format must replicate.
+  concern. The reference implementation enforces `revoked`/`destroyed` by
+  default when a local vault is present, and offers
+  `--no-enforce-key-status` to skip the check; neither the default nor the
+  escape hatch is a property every implementation of this format must
+  replicate.
 - **CLI syntax and error message text.**
 
 ## 11. Known non-goals of this format version

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -33,7 +33,7 @@ object can be opened by more than one independent credential.
 | **Passive Eavesdropper** | Read access to `.ssc` files on disk. | AES-256-GCM encryption of payload. The access grant does not reveal the DEK. |
 | **Active Tamperer** | Write access to `.ssc` files; ability to alter ciphertext, metadata, or the grant. | GCM authentication tag; HMAC-SHA256 grant commitment; strict header field validation and canonical-JSON re-verification. |
 | **Brute-force Attacker** | Offline computational capability to guess passwords. | Argon2id KDF (memory-hard; `time_cost=3`, `memory_kib=65536`, `parallelism=4` — OWASP-baseline, not unusually high); local CLI rate limiting on the interactive path only (see §5.4 — it does not slow an attacker operating directly against a copied file). |
-| **Key Compromiser** | Access to a stolen password or `.ssckey` file. | A grant built with `--require all` needs both components together, so a stolen password alone (or a stolen key alone) is insufficient for that object. **Not addressed**: `.ssckey` files store the raw 256-bit secret in plaintext (base64), so possession of the file is possession of the key — see §5.4. Revoking or destroying a key in the vault does not stop a copy of that key's file from decrypting unless `--vault LABEL` is also passed — see §5.5. |
+| **Key Compromiser** | Access to a stolen password or `.ssckey` file. | A grant built with `--require all` needs both components together, so a stolen password alone (or a stolen key alone) is insufficient for that object. **Not addressed**: `.ssckey` files store the raw 256-bit secret in plaintext (base64), so possession of the file is possession of the key — see §5.4. Revoking or destroying a key in the vault is enforced on the honest code paths but cannot stop a copy of that key's file from decrypting — see §5.5. |
 
 ## 4. Key Security Mechanisms in V2
 
@@ -98,16 +98,24 @@ only protection; anyone who obtains the bytes has the key, with no secondary
 factor required. `--require all` is the only mitigation, and only for objects
 deliberately encrypted that way (§4.2).
 
-### 5.5. Key lifecycle enforcement is opt-in, not automatic
+### 5.5. Key lifecycle enforcement is advisory, not cryptographic
 `ssc key archive` / `revoke` / `destroy` change a status field on the vault's
-metadata record for that key. By default, key resolution for
-`ssc encrypt --with key:ID` and `ssc decrypt` reads the `.ssckey` file
-directly and never queries the vault — a revoked or destroyed key you still
-physically hold keeps working, which is inherent to holding the file, not a
-bug. Passing `--vault LABEL` alongside a key source now unlocks the vault and
-rejects a `REVOKED`/`DESTROYED` key that this vault actually tracks (a bare
-`.ssckey` never registered in this vault can't be checked and is unaffected).
-`archive` never blocks use; it is bookkeeping only.
+metadata record for that key. `ssc encrypt --with key:ID` and `ssc decrypt`
+enforce that field by default: whenever a vault exists on this machine, the
+key's record is read and a `REVOKED`/`DESTROYED` key is refused. A bare
+`.ssckey` that was never registered in this vault cannot be checked and is
+unaffected; `archive` never blocks use, being bookkeeping only.
+
+The limit of this control is that it is advisory. The check runs inside the
+process the operator invokes, so `--no-enforce-key-status` — or a build with
+the check removed, or any independent implementation of the format — will
+decrypt with the raw secret regardless. That follows from §5.4: the `.ssckey`
+file *is* the key, and revocation cannot reach a copy of it. What the check
+does buy is that a revoked key stops working across the honest paths, so
+continued use requires a deliberate act that leaves a trace, rather than
+being the silent default. Revocation that must hold against a motivated
+holder of the file requires re-encrypting the affected objects under a new
+key.
 
 ### 5.6. Local rate limiting is bypassable, not a confidentiality risk
 The CLI's exponential-backoff rate limiter identifies a decrypt attempt by a

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -126,6 +126,9 @@ _master_password_source: str | None = None
 # would make `vault change-password` rotate to the password it already has.
 _new_master_password_source: str | None = None
 
+# Key-status enforcement runs by default; --no-enforce-key-status turns it off.
+_enforce_key_status = True
+
 # A password file is read with the same bound v2 applies to a password before
 # derivation, so an oversized file is refused rather than fed to Argon2id.
 _MAX_PASSWORD_FILE_BYTES = 65536
@@ -647,7 +650,7 @@ def cmd_encrypt(args: argparse.Namespace) -> int:
         if has_password and keys and require_all:
             password = _prompt_password("Enter password: ", confirm=True)
             key_data = _resolve_v2_key_source(keys[0])
-            if getattr(args, "vault", None):
+            if _enforce_key_status:
                 _enforce_v2_key_status(key_data.fingerprint)
             credential = CombinedCredential(
                 password, key_data.fingerprint, key_data.secret_bytes
@@ -657,7 +660,7 @@ def cmd_encrypt(args: argparse.Namespace) -> int:
             credential = PasswordCredential(password)
         elif keys:
             key_data = _resolve_v2_key_source(keys[0])
-            if getattr(args, "vault", None):
+            if _enforce_key_status:
                 _enforce_v2_key_status(key_data.fingerprint)
             credential = KeyCredential(key_data.fingerprint, key_data.secret_bytes)
         else:
@@ -1086,22 +1089,37 @@ def _get_v2_password(args: argparse.Namespace) -> str:
 
 
 def _enforce_v2_key_status(fingerprint: str) -> None:
-    """Reject a managed key that this vault has marked revoked or destroyed.
+    """Reject a managed key this vault has marked revoked or destroyed.
 
-    Encrypt/decrypt normally resolve ``.ssckey`` files straight off disk
-    (see ``_resolve_v2_key_source``) without ever touching the vault, so a
-    key you still physically hold keeps working even after ``ssc key
-    revoke``/``destroy`` — that's inherent to holding the file, not a bug.
-    This check is therefore opt-in: it only runs when the caller passes
-    ``--vault``, and even then a key with no matching vault record (a bare
-    ``.ssckey`` that was never registered) can't be checked and is let
-    through unchanged. It only closes the gap for keys this vault actually
-    tracks.
+    Holding a ``.ssckey`` is sufficient to use the key inside it, so ordinary
+    encrypt/decrypt reads the file straight off disk (see
+    ``_resolve_v2_key_source``). That is inherent to a bearer secret. This
+    check exists so that ``ssc key revoke``/``destroy`` mean something for a
+    key the vault actually tracks, and it runs by default.
+
+    Skipped entirely when no vault exists — there is nothing to consult, and
+    prompting would be pointless. A key the vault does not track cannot be
+    judged and passes through. ``archived`` never blocks use.
+
+    Reading status needs the master password, so this is the one place a
+    key-only operation may prompt. ``--master-password-file`` /
+    ``SSC_MASTER_PASSWORD`` avoid that for automation, and
+    ``--no-enforce-key-status`` skips the check altogether.
     """
     vault = PassphraseVault()
     if not vault.vault_exists():
         return
+
+    if _master_password_source is None:
+        # Explain the prompt at the moment it appears, so an operator who did
+        # not expect it learns both why it is there and how to opt out.
+        _print_info(
+            "Checking the key's status against the vault. "
+            "Use --no-enforce-key-status to skip, or --master-password-file "
+            "to avoid this prompt."
+        )
     master = _prompt_master_password()
+
     try:
         KeyStatusPolicy(V2VaultService(vault)).check(
             fingerprint, master_password=master
@@ -1111,10 +1129,18 @@ def _enforce_v2_key_status(fingerprint: str) -> None:
         _exit_error(
             EXIT_AUTH_ERROR,
             f"Key '{rejected_id}' is {rejected_status} in this vault; "
-            "refusing to use it.",
+            "refusing to use it. Pass --no-enforce-key-status to override.",
         )
     except VaultUnlockFailed:
-        _exit_error(EXIT_AUTH_ERROR, "Could not unlock vault to check key status.")
+        # Fail closed: proceeding here would report a status check that never
+        # happened. The override is explicit rather than implied by a failure,
+        # since anyone holding the keyfile can pass it anyway — the check
+        # guards against accident, not against a determined holder.
+        _exit_error(
+            EXIT_AUTH_ERROR,
+            "Could not unlock the vault to check key status. Pass "
+            "--no-enforce-key-status to proceed without checking.",
+        )
 
 
 def _resolve_v2_credential_from_header(
@@ -1145,7 +1171,7 @@ def _resolve_v2_credential_from_header(
     if requirement.needs_managed_key:
         assert requirement.key_fingerprint is not None
         key_data = _resolve_v2_key_source(key_file_ref or requirement.key_fingerprint)
-        if getattr(args, "vault", None):
+        if _enforce_key_status:
             _enforce_v2_key_status(requirement.key_fingerprint)
 
     return build_credential(requirement, password=password, key_data=key_data)
@@ -1933,6 +1959,15 @@ Run 'ssc <command> --help' for command-specific help.
         ),
     )
     parser.add_argument(
+        "--no-enforce-key-status",
+        action="store_true",
+        help=(
+            "Do not check a managed key's vault status before using it. "
+            "By default a key this vault records as revoked or destroyed is "
+            "refused, which requires the vault master password"
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help=(
@@ -2296,7 +2331,10 @@ Examples:
     # key revoke
     key_revoke_parser = key_subparsers.add_parser(
         "revoke",
-        help="Set status=revoked (enforced at encrypt/decrypt only with --vault)",
+        help=(
+            "Set status=revoked (enforced at encrypt/decrypt unless "
+            "--no-enforce-key-status)"
+        ),
     )
     key_revoke_parser.add_argument("id", metavar="ID", help="Key ID")
     key_revoke_parser.set_defaults(func=cmd_key_revoke)
@@ -2434,7 +2472,7 @@ def _classify_failure(error: BaseException) -> tuple[int, str]:
 
 def main() -> NoReturn:
     """Main entry point for ssc CLI."""
-    global _quiet_mode, _no_color, _debug_mode
+    global _quiet_mode, _no_color, _debug_mode, _enforce_key_status
 
     parser = create_parser()
     args = parser.parse_args()
@@ -2443,6 +2481,7 @@ def main() -> NoReturn:
     _quiet_mode = args.quiet
     _no_color = args.no_color
     _debug_mode = args.debug or _env_flag_enabled("SSC_DEBUG")
+    _enforce_key_status = not getattr(args, "no_enforce_key_status", False)
     _resolve_credential_sources(args)
 
     # No command specified

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,7 @@ def reset_cli_output_flags() -> Generator[None]:
         "_password_source",
         "_master_password_source",
         "_new_master_password_source",
+        "_enforce_key_status",
     )
     saved = {name: getattr(cli_args, name) for name in names if hasattr(cli_args, name)}
 

--- a/tests/unit/test_v2_cli_e2e.py
+++ b/tests/unit/test_v2_cli_e2e.py
@@ -545,15 +545,42 @@ def test_v2_cli_encrypt_with_vault_allows_archived_key(
     assert rc == cli_args.EXIT_SUCCESS
 
 
-def test_v2_cli_encrypt_without_vault_flag_ignores_revoked_status(
+def test_v2_cli_encrypt_rejects_revoked_status_without_the_vault_flag(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Without --vault, enforcement never runs: a physically-held .ssckey
-    file keeps working after revoke, matching documented behavior (this is
-    the existing, deliberately offline-friendly default, not the gap)."""
+    """Enforcement no longer needs --vault to opt in.
+
+    Revocation that a physically-held .ssckey could simply ignore was
+    revocation in name only, so the check now runs whenever a vault is
+    present, whether or not --vault was passed.
+    """
     home = tmp_path / "home"
     _use_hermetic_home(monkeypatch, home)
     _register_key_in_vault(home, status="revoked")
+    _mock_master_password(monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_args.cmd_encrypt(
+            _encrypt_args(text="secret", with_sources=[f"key:{_FINGERPRINT}"])
+        )
+    assert excinfo.value.code == cli_args.EXIT_AUTH_ERROR
+    assert "revoked" in capsys.readouterr().err.lower()
+
+
+def test_v2_cli_encrypt_ignores_revoked_status_when_enforcement_is_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--no-enforce-key-status restores the offline-friendly behaviour.
+
+    The holder of a .ssckey can always use the key it contains — that is
+    inherent to a bearer secret. The flag exists so that an operator who
+    knows the vault is unreachable can proceed deliberately rather than
+    being blocked by a check that cannot complete.
+    """
+    home = tmp_path / "home"
+    _use_hermetic_home(monkeypatch, home)
+    _register_key_in_vault(home, status="revoked")
+    monkeypatch.setattr(cli_args, "_enforce_key_status", False)
 
     rc = cli_args.cmd_encrypt(
         _encrypt_args(text="secret", with_sources=[f"key:{_FINGERPRINT}"])

--- a/tests/unit/test_v2_key_cli_e2e.py
+++ b/tests/unit/test_v2_key_cli_e2e.py
@@ -294,9 +294,15 @@ def test_key_archive_sets_status_but_never_blocks_use(
     assert rc == cli_args.EXIT_SUCCESS
 
 
-def test_key_revoke_blocks_use_only_with_vault_flag(
+def test_key_revoke_blocks_use_by_default(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """A revoke set by this exact CLI command is enforced without any flag.
+
+    Enforcement used to be opt-in via --vault, which meant `ssc key revoke`
+    had no effect on a key the operator still held unless they knew to pass an
+    unrelated password label. It now runs whenever a vault exists.
+    """
     keys_dir = Path(os.environ["HOME"]) / ".ssc" / "keys"
     keys_dir.mkdir(parents=True)
     dest = keys_dir / "revoked-key.ssckey"
@@ -308,21 +314,55 @@ def test_key_revoke_blocks_use_only_with_vault_flag(
     assert rc == cli_args.EXIT_SUCCESS
     assert "revoked" in capsys.readouterr().err
 
-    # Without --vault: the CLI's default offline behavior is unchanged.
+    with pytest.raises(SystemExit) as excinfo:
+        cli_args.cmd_encrypt(
+            _encrypt_args(text="secret", with_sources=["key:revoked-key"])
+        )
+    assert excinfo.value.code == cli_args.EXIT_AUTH_ERROR
+    message = capsys.readouterr().err.lower()
+    assert "revoked" in message
+    assert "--no-enforce-key-status" in message, (
+        "the refusal must name the override, or an operator hits a wall"
+    )
+
+
+def test_revoked_key_is_usable_when_enforcement_is_disabled(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--no-enforce-key-status restores the offline behaviour deliberately.
+
+    Holding the keyfile is sufficient to use the key, so the override has to
+    exist; what changed is that it is now an explicit choice rather than the
+    default.
+    """
+    keys_dir = Path(os.environ["HOME"]) / ".ssc" / "keys"
+    keys_dir.mkdir(parents=True)
+    dest = keys_dir / "revoked-key.ssckey"
+    cli_args.cmd_key_create(_create_args("revoked-key", external_file=str(dest)))
+    cli_args.cmd_key_revoke(_id_args("revoked-key"))
+    capsys.readouterr()
+
+    monkeypatch.setattr(cli_args, "_enforce_key_status", False)
     rc = cli_args.cmd_encrypt(
         _encrypt_args(text="secret", with_sources=["key:revoked-key"])
     )
     assert rc == cli_args.EXIT_SUCCESS
 
-    # With --vault: the revoke set by this exact CLI command is enforced.
-    with pytest.raises(SystemExit) as excinfo:
-        cli_args.cmd_encrypt(
-            _encrypt_args(
-                text="secret", with_sources=["key:revoked-key"], vault="anything"
-            )
-        )
-    assert excinfo.value.code == cli_args.EXIT_AUTH_ERROR
-    assert "revoked" in capsys.readouterr().err.lower()
+
+def test_active_key_is_unaffected_by_enforcement(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The common case must not become harder: an active key still works."""
+    keys_dir = Path(os.environ["HOME"]) / ".ssc" / "keys"
+    keys_dir.mkdir(parents=True)
+    dest = keys_dir / "live-key.ssckey"
+    cli_args.cmd_key_create(_create_args("live-key", external_file=str(dest)))
+    capsys.readouterr()
+
+    rc = cli_args.cmd_encrypt(
+        _encrypt_args(text="secret", with_sources=["key:live-key"])
+    )
+    assert rc == cli_args.EXIT_SUCCESS
 
 
 def test_key_destroy_with_confirm_flag_removes_recoverable_secret(
@@ -346,13 +386,12 @@ def test_key_destroy_with_confirm_flag_removes_recoverable_secret(
     assert excinfo.value.code == cli_args.EXIT_VAULT_ERROR
 
 
-def test_key_destroy_blocks_decrypt_only_with_vault_flag(
-    capsys: pytest.CaptureFixture[str],
+def test_key_destroy_blocks_decrypt_by_default(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The revoke test above chains into cmd_encrypt; this one chains into
-    cmd_decrypt specifically, so both directions of the --vault key-status
-    enforcement (added in B2.6) are actually exercised through the CLI
-    commands that set the status, not just one of the two."""
+    cmd_decrypt, so both directions of key-status enforcement are exercised
+    through the CLI commands that actually set the status."""
     keys_dir = Path(os.environ["HOME"]) / ".ssc" / "keys"
     keys_dir.mkdir(parents=True)
     dest = keys_dir / "doomed-key.ssckey"
@@ -383,11 +422,13 @@ def test_key_destroy_blocks_decrypt_only_with_vault_flag(
         base.update(overrides)
         return argparse.Namespace(**base)
 
-    # Without --vault: destroying the vault record doesn't touch the
-    # physical .ssckey file, so offline decryption is unaffected.
+    # With enforcement disabled, destroying the vault record leaves the
+    # physical .ssckey untouched, so decryption still works.
+    monkeypatch.setattr(cli_args, "_enforce_key_status", False)
     rc = cli_args.cmd_decrypt(_decrypt_args())
     assert rc == cli_args.EXIT_SUCCESS
     assert capsys.readouterr().out.strip() == "secret"
+    monkeypatch.setattr(cli_args, "_enforce_key_status", True)
 
     # With --vault: the destroy set by this exact CLI command is enforced.
     with pytest.raises(SystemExit) as excinfo:
@@ -425,3 +466,23 @@ def test_key_destroy_without_confirm_prompts_and_can_proceed(
 
     cli_args.cmd_key_show(_id_args("prompted-doomed"))
     assert "Status: destroyed" in capsys.readouterr().out
+
+
+def test_enforcement_is_on_by_default_and_the_flag_is_a_global_option() -> None:
+    """The opt-out is a top-level flag, so it precedes the subcommand.
+
+    Asserted here because the position is invisible until it fails: placed
+    after the subcommand, argparse rejects it as an unrecognized argument,
+    and a documented example that cannot run is worse than none. Verified
+    together with the default so the two cannot drift apart.
+    """
+    parser = cli_args.create_parser()
+
+    args = parser.parse_args(["encrypt", "-t", "x"])
+    assert args.no_enforce_key_status is False
+
+    args = parser.parse_args(["--no-enforce-key-status", "encrypt", "-t", "x"])
+    assert args.no_enforce_key_status is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["encrypt", "-t", "x", "--no-enforce-key-status"])


### PR DESCRIPTION
Closes #95. No longer stacked: #118 and #121 (which replaced the auto-closed #119) are both on `main`, and this branch was rebuilt directly on top of them, so the diff here is this change alone. Verified the rebuilt patch is content-identical to what was reviewed while it was stacked.

## The gap

`ssc key revoke` / `destroy` set a status field on the vault's record for a
key. Encrypt and decrypt only read that field when the operator also passed
`--vault LABEL`. Nothing about revoking a key implies wanting to name a
vault on the next encrypt, so the check ran for almost nobody: revocation
was bookkeeping the default path ignored.

## What changed

The check now runs whenever a vault exists on this machine:

- a key that vault records as `revoked` or `destroyed` is refused (exit 2);
- a key it does not track cannot be judged and passes through;
- `archived` still never blocks use;
- with no vault present, nothing happens at all — no check, no prompt.

`--no-enforce-key-status` (a global flag, so it precedes the subcommand)
opts out.

## Why this needed #119 first

Reading key status needs the vault master password, so default-on
enforcement introduces a prompt into the only scriptable v2 key path.
That would have been a regression on its own. Three things prevent it:
#119's `--master-password-file` / `SSC_MASTER_PASSWORD` supply the password
without a prompt, a machine with no vault skips the check entirely, and the
opt-out flag exists. When the prompt does appear, an info line says why it
is there and names the flag, rather than leaving an unexplained password
request in the middle of an encrypt.

`VaultUnlockFailed` fails closed: continuing would report a status check
that never happened, and the override reads better as a deliberate act than
as the silent consequence of an unreadable vault.

## Breaking change, and it is in the CHANGELOG as one

A command that succeeded before can now exit 2, and a key-only operation on
a machine with a vault can now prompt. Both are stated in the `Changed`
section.

## Honesty pass on the docs

The old wording let a reader infer that revocation reaches a copy of the key
file. It does not: whoever holds a `.ssckey` holds the key inside it, so an
offline holder can always proceed, and so can `--no-enforce-key-status`.
`docs/THREAT_MODEL.md` §5.5 is retitled "advisory, not cryptographic" and
now states that limit outright, along with what the default does buy —
a revoked key stops working on the honest paths, so continued use takes a
visible step. README, ROADMAP, MIGRATION and the protocol spec's
local-policy section are updated to match.

Two stale claims fixed in passing, both in `docs/MIGRATION.md`: it still
said there was no CLI end-to-end coverage for the `ssc key` group (all nine
`cmd_key_*` functions have been covered since #81), and the `key
archive/revoke/destroy` comment block still described the `--vault`
coupling.

## Verification

- 1678 tests pass; `ruff check` / `ruff format --check` / `mypy src` /
  `tools/check_sensitive_output.py` clean on `src tests tools`.
- **Falsified:** flipping the default back to opt-in fails five tests —
  three in `test_v2_cli_e2e.py`, two in `test_v2_key_cli_e2e.py`.
- One test asserts the flag's *position*, because a global flag placed after
  the subcommand is rejected by argparse. I had written two documented
  examples that way; the test caught them and both are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
