### PR TITLE
feat(cli): supply passwords from a file or the environment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "README.md",
         "hashed_secret": "eeb7f851dfdec7a9f083802e5454d0c98fa9d616",
         "is_verified": false,
-        "line_number": 436
+        "line_number": 446
       }
     ],
     "src/secure_string_cipher/audit_log.py": [
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 543
+        "line_number": 618
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T22:04:02Z"
+  "generated_at": "2026-09-12T21:59:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "README.md",
         "hashed_secret": "eeb7f851dfdec7a9f083802e5454d0c98fa9d616",
         "is_verified": false,
-        "line_number": 410
+        "line_number": 436
       }
     ],
     "src/secure_string_cipher/audit_log.py": [
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 453
+        "line_number": 543
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T21:12:58Z"
+  "generated_at": "2026-09-12T22:04:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 618
+        "line_number": 632
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T21:59:16Z"
+  "generated_at": "2026-09-12T22:31:55Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
   would re-encrypt the vault with the password it already had while
   reporting a successful rotation. That command now refuses to run when only
   the current password was supplied, and refuses a new password equal to the
-  old one.
+  old one. A credential file is opened with `O_NOFOLLOW` and validated with
+  `fstat`, so the type and permission checks apply to the descriptor that is
+  read rather than to the path as it looked a moment earlier, and with
+  `O_BINARY` so that Windows cannot collapse a CRLF or truncate at a
+  control-Z inside a password before it is read.
 
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,
@@ -38,6 +42,13 @@
   be decided — the module is importable but not yet re-exported.
 
 ### Fixed
+
+- **`.ssckey` files are now read in binary mode.** `load_keyfile` opened the
+  descriptor without `O_BINARY`, so on Windows the C runtime collapsed CRLF
+  to LF and truncated at a control-Z before the parser saw the bytes —
+  defeating `parse_keyfile_content`'s own deliberate rejection of mixed line
+  endings and bare carriage returns, and silently shortening a keyfile that
+  happened to contain a control-Z.
 
 - **Stale "V2 not yet released" banners.** `docs/API.md`'s "V2 Encryption"
   heading still said "(in progress, unreleased — see ROADMAP.md)", and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- **Non-interactive credentials: `--password-file` / `SSC_PASSWORD` and
+  `--master-password-file` / `SSC_MASTER_PASSWORD`.** There was previously no
+  way to supply a password without a prompt, so v2 password mode and v2
+  combined mode could not be scripted at all, and anything touching the vault
+  required an interactive master password. Piping worked only via CPython's
+  degraded `getpass` fallback, which prints a warning and has no Windows
+  equivalent. The flag takes precedence over the variable. A password file
+  must be a regular file, not reached through a symlink, and on POSIX not
+  group/other-readable; one trailing newline is stripped; an empty,
+  oversized or non-UTF-8 file is refused. A supplied password is still
+  strength-checked where a new password is being set, and fails rather than
+  looping since it cannot be re-prompted.
+
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,
   header→requirement mapping, armoured-header parsing and credential

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@
   group/other-readable; one trailing newline is stripped; an empty,
   oversized or non-UTF-8 file is refused. A supplied password is still
   strength-checked where a new password is being set, and fails rather than
-  looping since it cannot be re-prompted.
+  looping since it cannot be re-prompted. A third source,
+  `--new-master-password-file` / `SSC_NEW_MASTER_PASSWORD`, supplies the
+  replacement value for `ssc vault change-password`: setting a master
+  password and using one are separate roles, and a single value read as both
+  would re-encrypt the vault with the password it already had while
+  reporting a successful rotation. That command now refuses to run when only
+  the current password was supplied, and refuses a new password equal to the
+  old one.
 
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,

--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ contain accepted changes that have not yet been included in a release.
 
 For scripting and automation, use the `ssc` command:
 
+#### Supplying credentials without a prompt
+
+Passwords are read interactively by default. For automation, supply them
+from a file or the environment:
+
+```bash
+# The data password
+ssc --password-file /run/secrets/pw encrypt -f document.pdf --with password
+SSC_PASSWORD="..." ssc encrypt -f document.pdf --with password
+
+# The vault master password, for vault and key commands
+ssc --master-password-file /run/secrets/master key list
+SSC_MASTER_PASSWORD="..." ssc key list
+```
+
+The flag wins over the variable, so a stale exported value cannot quietly
+override what the command line asked for. A password file must be a regular
+file, not reached through a symlink, and on POSIX not readable by group or
+other — it is a bearer secret, so a world-readable one is refused rather
+than used with a warning. One trailing newline is removed, since a file
+written with `echo` has one.
+
+Prefer a file over an environment variable where you can: on some systems a
+process's environment is readable by other processes owned by the same user,
+and variables are easily captured in shell history and CI logs.
+
 ```bash
 # Encrypt text
 ssc encrypt -t "Secret message"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,17 @@ SSC_PASSWORD="..." ssc encrypt -f document.pdf --with password
 # The vault master password, for vault and key commands
 ssc --master-password-file /run/secrets/master key list
 SSC_MASTER_PASSWORD="..." ssc key list
+
+# Rotating the master password needs both values, since one of them is
+# being replaced
+ssc --master-password-file /run/secrets/old \
+    --new-master-password-file /run/secrets/new vault change-password
 ```
+
+Setting a master password and using one are separate roles, so they have
+separate sources. `vault change-password` refuses to run if only the
+current one was supplied: reusing it would re-encrypt the vault with the
+password it already has and report a successful rotation.
 
 The flag wins over the variable, so a stale exported value cannot quietly
 override what the command line asked for. A password file must be a regular

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -82,6 +82,7 @@ from .v2.encrypt import (
 )
 from .v2.keyfile import KeyFileData
 from .v2.keywrap import KeyWrapError
+from .v2.paths import reject_symlink_components
 from .v2.vault_lock import VaultBusyError
 from .v2.vault_service import (
     KeyExportSurvivedRegistrationFailureError,
@@ -113,6 +114,16 @@ _V2_DECRYPT_FAILURE_MESSAGE = "Decryption failed. Wrong password/key or corrupte
 _quiet_mode = False
 _no_color = False
 _debug_mode = False
+
+# Non-interactive credential sources, resolved once in main(). Held as module
+# state for the same reason as the flags above: the prompt helpers are called
+# from many places that have no access to the parsed arguments.
+_password_source: str | None = None
+_master_password_source: str | None = None
+
+# A password file is read with the same bound v2 applies to a password before
+# derivation, so an oversized file is refused rather than fed to Argon2id.
+_MAX_PASSWORD_FILE_BYTES = 65536
 
 
 class _StdinSizeError(CryptoError):
@@ -262,16 +273,83 @@ def _audit_rate_limit(operation: str, wait: float, identifier: str = "") -> None
 # =============================================================================
 
 
+def _read_password_file(path_str: str, *, role: str) -> str:
+    """Read a credential from a file, refusing an unsafe or implausible one.
+
+    Held to the same standard as a `.ssckey`: a regular file, not reached
+    through a symlink, and on POSIX not readable by group or other. A password
+    file is a bearer secret, so a world-readable one is refused rather than
+    used with a warning.
+
+    One trailing line ending is removed — a file written with `echo` has one
+    and the operator does not intend it as part of the password — using the
+    same helper as the stdin path so both agree.
+    """
+    path = Path(path_str).expanduser()
+    try:
+        reject_symlink_components(path)
+        if not path.is_file():
+            _exit_error(EXIT_FILE_ERROR, f"{role} file is not a regular file: {path}")
+        if os.name == "posix" and (path.stat().st_mode & 0o077):
+            _exit_error(
+                EXIT_FILE_ERROR,
+                f"{role} file is readable by group or other: {path}. "
+                "Restrict it with chmod 600.",
+            )
+        with open(path, "rb") as handle:
+            raw = handle.read(_MAX_PASSWORD_FILE_BYTES + 1)
+    except OSError as error:
+        detail = error.strerror or "could not be read"
+        _exit_error(EXIT_FILE_ERROR, f"{role} file {detail}: {path}")
+
+    if len(raw) > _MAX_PASSWORD_FILE_BYTES:
+        _exit_error(EXIT_INPUT_ERROR, f"{role} file exceeds the permitted length.")
+
+    value = _remove_one_terminal_line_ending(raw)
+    if not value:
+        _exit_error(EXIT_INPUT_ERROR, f"{role} file is empty: {path}")
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError:
+        _exit_error(EXIT_INPUT_ERROR, f"{role} file is not valid UTF-8: {path}")
+
+
+def _resolve_credential_sources(args: argparse.Namespace) -> None:
+    """Record any non-interactive credential sources the operator supplied.
+
+    An explicit flag wins over an environment variable: naming a file is the
+    more deliberate act, and it keeps a stale exported variable from quietly
+    overriding what the command line asked for.
+    """
+    global _password_source, _master_password_source
+
+    if getattr(args, "password_file", None):
+        _password_source = _read_password_file(args.password_file, role="Password")
+    elif os.environ.get("SSC_PASSWORD"):
+        _password_source = os.environ["SSC_PASSWORD"]
+
+    if getattr(args, "master_password_file", None):
+        _master_password_source = _read_password_file(
+            args.master_password_file, role="Master password"
+        )
+    elif os.environ.get("SSC_MASTER_PASSWORD"):
+        _master_password_source = os.environ["SSC_MASTER_PASSWORD"]
+
+
 def _prompt_password(prompt: str = "Password: ", confirm: bool = False) -> str:
-    """Prompt for password with hidden input.
+    """Obtain the data password, without prompting if a source was supplied.
 
     Args:
         prompt: The prompt to display
-        confirm: If True, ask for confirmation
+        confirm: If True, ask for confirmation. Skipped for a supplied source,
+            which has nothing to confirm against.
 
     Returns:
-        The entered password
+        The password
     """
+    if _password_source is not None:
+        return _password_source
+
     password = getpass.getpass(prompt)
 
     if confirm:
@@ -291,6 +369,16 @@ def _prompt_password_with_validation(prompt: str = "Password: ") -> str:
     Returns:
         A valid password meeting strength requirements
     """
+    if _password_source is not None:
+        # A supplied source cannot be re-prompted, so a weak value is a hard
+        # failure rather than the interactive retry loop below.
+        is_strong, _ = check_password_strength(_password_source)
+        if not is_strong:
+            _print_error("Supplied password does not meet security requirements:")
+            _print_password_policy()
+            _exit_error(EXIT_INPUT_ERROR, "Supplied password is too weak.")
+        return _password_source
+
     while True:
         password = getpass.getpass(prompt)
         is_strong, _ = check_password_strength(password)
@@ -308,7 +396,9 @@ def _prompt_password_with_validation(prompt: str = "Password: ") -> str:
 
 
 def _prompt_master_password() -> str:
-    """Prompt for vault master password."""
+    """Obtain the vault master password, without prompting if one was supplied."""
+    if _master_password_source is not None:
+        return _master_password_source
     return getpass.getpass("Master password: ")
 
 
@@ -1706,6 +1796,23 @@ Run 'ssc <command> --help' for command-specific help.
         help="Disable colored output",
     )
     parser.add_argument(
+        "--password-file",
+        metavar="PATH",
+        help=(
+            "Read the data password from PATH instead of prompting "
+            "(or set SSC_PASSWORD; the flag wins). Must not be readable by "
+            "group or other."
+        ),
+    )
+    parser.add_argument(
+        "--master-password-file",
+        metavar="PATH",
+        help=(
+            "Read the vault master password from PATH instead of prompting "
+            "(or set SSC_MASTER_PASSWORD; the flag wins)"
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help=(
@@ -2216,6 +2323,7 @@ def main() -> NoReturn:
     _quiet_mode = args.quiet
     _no_color = args.no_color
     _debug_mode = args.debug or _env_flag_enabled("SSC_DEBUG")
+    _resolve_credential_sources(args)
 
     # No command specified
     if not args.command:

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -13,6 +13,7 @@ import argparse
 import getpass
 import hashlib
 import os
+import stat
 import sys
 import traceback
 from pathlib import Path
@@ -120,6 +121,10 @@ _debug_mode = False
 # from many places that have no access to the parsed arguments.
 _password_source: str | None = None
 _master_password_source: str | None = None
+# A master password being *set* is a different value from the one being used to
+# unlock, so it gets its own source. Reusing _master_password_source for both
+# would make `vault change-password` rotate to the password it already has.
+_new_master_password_source: str | None = None
 
 # A password file is read with the same bound v2 applies to a password before
 # derivation, so an oversized file is refused rather than fed to Argon2id.
@@ -284,20 +289,42 @@ def _read_password_file(path_str: str, *, role: str) -> str:
     One trailing line ending is removed — a file written with `echo` has one
     and the operator does not intend it as part of the password — using the
     same helper as the stdin path so both agree.
+
+    The checks are made against the open descriptor rather than the path, so
+    that replacing the final component between the check and the read cannot
+    substitute a different file: `O_NOFOLLOW` refuses a symlink put there,
+    and `fstat` re-checks type and permissions on what was actually opened.
+    This mirrors `v2/keyfile.py`'s loader, which guards the same race for the
+    other bearer secret this program reads.
     """
     path = Path(path_str).expanduser()
     try:
         reject_symlink_components(path)
-        if not path.is_file():
-            _exit_error(EXIT_FILE_ERROR, f"{role} file is not a regular file: {path}")
-        if os.name == "posix" and (path.stat().st_mode & 0o077):
-            _exit_error(
-                EXIT_FILE_ERROR,
-                f"{role} file is readable by group or other: {path}. "
-                "Restrict it with chmod 600.",
-            )
-        with open(path, "rb") as handle:
-            raw = handle.read(_MAX_PASSWORD_FILE_BYTES + 1)
+
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        try:
+            st = os.fstat(fd)
+            if not stat.S_ISREG(st.st_mode):
+                _exit_error(
+                    EXIT_FILE_ERROR, f"{role} file is not a regular file: {path}"
+                )
+            if os.name == "posix" and (st.st_mode & 0o077):
+                _exit_error(
+                    EXIT_FILE_ERROR,
+                    f"{role} file is readable by group or other: {path}. "
+                    "Restrict it with chmod 600.",
+                )
+            raw = b""
+            while len(raw) <= _MAX_PASSWORD_FILE_BYTES:
+                chunk = os.read(fd, _MAX_PASSWORD_FILE_BYTES + 1 - len(raw))
+                if not chunk:
+                    break
+                raw += chunk
+        finally:
+            os.close(fd)
     except OSError as error:
         detail = error.strerror or "could not be read"
         _exit_error(EXIT_FILE_ERROR, f"{role} file {detail}: {path}")
@@ -321,7 +348,7 @@ def _resolve_credential_sources(args: argparse.Namespace) -> None:
     more deliberate act, and it keeps a stale exported variable from quietly
     overriding what the command line asked for.
     """
-    global _password_source, _master_password_source
+    global _password_source, _master_password_source, _new_master_password_source
 
     if getattr(args, "password_file", None):
         _password_source = _read_password_file(args.password_file, role="Password")
@@ -334,6 +361,13 @@ def _resolve_credential_sources(args: argparse.Namespace) -> None:
         )
     elif os.environ.get("SSC_MASTER_PASSWORD"):
         _master_password_source = os.environ["SSC_MASTER_PASSWORD"]
+
+    if getattr(args, "new_master_password_file", None):
+        _new_master_password_source = _read_password_file(
+            args.new_master_password_file, role="New master password"
+        )
+    elif os.environ.get("SSC_NEW_MASTER_PASSWORD"):
+        _new_master_password_source = os.environ["SSC_NEW_MASTER_PASSWORD"]
 
 
 def _prompt_password(prompt: str = "Password: ", confirm: bool = False) -> str:
@@ -402,6 +436,40 @@ def _prompt_master_password() -> str:
     return getpass.getpass("Master password: ")
 
 
+def _prompt_master_password_to_set(
+    prompt: str, *, supplied: str | None, source_flag: str
+) -> str:
+    """Obtain a master password that is being *set*, not used to unlock.
+
+    Setting and unlocking are separate roles even though both are "the master
+    password": initialising a vault sets one, and `vault change-password` uses
+    the old one while setting a new one. Giving each role its own source is
+    what stops a single supplied value being read as both, which would rotate
+    a vault to the password it already had and report success.
+
+    A supplied value is strength-checked and fails hard rather than falling
+    back to a prompt, since a non-interactive caller cannot answer one.
+    """
+    if supplied is not None:
+        is_strong, _ = check_password_strength(supplied)
+        if not is_strong:
+            _print_error(f"Supplied master password ({source_flag}) is too weak:")
+            _print_password_policy()
+            _exit_error(EXIT_INPUT_ERROR, "Supplied master password is too weak.")
+        return supplied
+
+    while True:
+        password = getpass.getpass(prompt)
+        is_strong, _ = check_password_strength(password)
+        if is_strong:
+            if password != getpass.getpass("Confirm master password: "):
+                _print_error("Passwords do not match. Try again.")
+                continue
+            return password
+        _print_error("Master password does not meet security requirements:")
+        _print_password_policy()
+
+
 def _get_vault() -> PassphraseVault:
     """Get or initialize the vault."""
     vault = PassphraseVault()
@@ -415,7 +483,14 @@ def _get_vault() -> PassphraseVault:
 
         # Initialize vault
         print()
-        master = _prompt_password_with_validation("Set master password: ")
+        # The master source, not the data-password source: an operator who
+        # passes both files means the master one here, and initialising with
+        # the data password would leave the very next unlock failing.
+        master = _prompt_master_password_to_set(
+            "Set master password: ",
+            supplied=_master_password_source,
+            source_flag="--master-password-file / SSC_MASTER_PASSWORD",
+        )
         # Store a dummy entry to initialize, then delete it
         vault.store_passphrase("__init__", "init", master)
         vault.delete_passphrase("__init__", master)
@@ -1475,8 +1550,31 @@ def cmd_vault_change_password(args: argparse.Namespace) -> int:
     vault = PassphraseVault()
     _print_info("Enter current master password:")
     old_master = _prompt_master_password()
+
+    if _master_password_source is not None and _new_master_password_source is None:
+        # Falling back to an interactive prompt here would hang an unattended
+        # run, and reusing the supplied value would re-encrypt the vault with
+        # the password it already has while reporting a successful rotation.
+        _exit_error(
+            EXIT_INPUT_ERROR,
+            "The current master password was supplied, so the new one must be "
+            "too: pass --new-master-password-file PATH (or set "
+            "SSC_NEW_MASTER_PASSWORD). Reusing the current password would "
+            "report a rotation that did not happen.",
+        )
+
     _print_info("Enter new master password:")
-    new_master = _prompt_master_password()
+    new_master = _prompt_master_password_to_set(
+        "New master password: ",
+        supplied=_new_master_password_source,
+        source_flag="--new-master-password-file / SSC_NEW_MASTER_PASSWORD",
+    )
+    if new_master == old_master:
+        _exit_error(
+            EXIT_INPUT_ERROR,
+            "The new master password is the same as the current one; nothing "
+            "was changed.",
+        )
     service = V2VaultService(vault)
     try:
         service.change_master_password(old_master, new_master)
@@ -1810,6 +1908,14 @@ Run 'ssc <command> --help' for command-specific help.
         help=(
             "Read the vault master password from PATH instead of prompting "
             "(or set SSC_MASTER_PASSWORD; the flag wins)"
+        ),
+    )
+    parser.add_argument(
+        "--new-master-password-file",
+        metavar="PATH",
+        help=(
+            "Read the replacement master password for `vault change-password` "
+            "from PATH (or set SSC_NEW_MASTER_PASSWORD; the flag wins)"
         ),
     )
     parser.add_argument(

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -296,12 +296,25 @@ def _read_password_file(path_str: str, *, role: str) -> str:
     and `fstat` re-checks type and permissions on what was actually opened.
     This mirrors `v2/keyfile.py`'s loader, which guards the same race for the
     other bearer secret this program reads.
+
+    What that does *not* cover is an ancestor directory swapped for a symlink
+    between `reject_symlink_components` and the open — `O_NOFOLLOW` applies to
+    the final component only. Closing that would mean resolving every
+    component through `openat`, and it is not worth the complexity here: an
+    attacker who can replace an ancestor directory does not need the race,
+    since they can leave the substitution in place and be read by every later
+    run. The capability, not the window, is what defeats this check.
     """
     path = Path(path_str).expanduser()
     try:
         reject_symlink_components(path)
 
-        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        # O_BINARY matters on Windows, where the CRT would otherwise translate
+        # CRLF and stop at a control-Z before os.read returned the bytes. This
+        # function decides for itself which trailing line ending to remove, so
+        # a silent rewrite of the file's actual bytes would corrupt a password
+        # containing either.
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         fd = os.open(path, flags)
@@ -336,9 +349,10 @@ def _read_password_file(path_str: str, *, role: str) -> str:
     if not value:
         _exit_error(EXIT_INPUT_ERROR, f"{role} file is empty: {path}")
     try:
-        return value.decode("utf-8")
+        decoded = value.decode("utf-8")
     except UnicodeDecodeError:
         _exit_error(EXIT_INPUT_ERROR, f"{role} file is not valid UTF-8: {path}")
+    return decoded
 
 
 def _resolve_credential_sources(args: argparse.Namespace) -> None:

--- a/src/secure_string_cipher/v2/keyfile.py
+++ b/src/secure_string_cipher/v2/keyfile.py
@@ -184,7 +184,11 @@ def load_keyfile(path: Path) -> KeyFileData:
     if path.is_symlink():
         raise OSError(f"{path} is a symlink, which is not permitted for keyfiles")
 
-    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+    # O_BINARY is required for parse_keyfile_content's line-ending validation
+    # to mean anything on Windows: without it the CRT translates CRLF to LF
+    # before the parser can reject a mixed-ending file, and truncates at a
+    # control-Z.
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,7 @@ def reset_cli_output_flags() -> Generator[None]:
         "_debug_mode",
         "_password_source",
         "_master_password_source",
+        "_new_master_password_source",
     )
     saved = {name: getattr(cli_args, name) for name in names if hasattr(cli_args, name)}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,21 +138,28 @@ def reset_environment() -> Generator[None]:
 
 @pytest.fixture(autouse=True)
 def reset_cli_output_flags() -> Generator[None]:
-    """Restore cli_args' module-level output flags after each test.
+    """Restore cli_args' module-level flags after each test.
 
-    `_quiet_mode` and `_no_color` are process-wide globals that gate
-    `_print_info`/`_print_warning`. 39 tests in tests/unit/test_cli_args.py
-    set them to True without restoring, so every later test in the same
-    xdist worker saw silenced output — a latent order dependency that showed
-    up as `CaptureResult(out='', err='')` in the `ssc key` end-to-end tests
-    on whichever Python version happened to distribute them together.
+    `_quiet_mode` and `_no_color` gate `_print_info`/`_print_warning`, and 39
+    tests in tests/unit/test_cli_args.py set them to True without restoring.
+    Every later test in the same xdist worker then saw silenced output — a
+    latent order dependency that surfaced as `CaptureResult(out='', err='')`
+    in the `ssc key` end-to-end tests on whichever Python version happened to
+    distribute those files together.
 
-    Restoring here keeps that coupling from mattering, rather than relying on
-    the worker layout staying lucky.
+    The credential sources matter more: a leaked `_password_source` would
+    make a later test appear to succeed without prompting, hiding exactly the
+    behaviour it meant to exercise.
     """
     from secure_string_cipher import cli_args
 
-    names = ("_quiet_mode", "_no_color", "_debug_mode")
+    names = (
+        "_quiet_mode",
+        "_no_color",
+        "_debug_mode",
+        "_password_source",
+        "_master_password_source",
+    )
     saved = {name: getattr(cli_args, name) for name in names if hasattr(cli_args, name)}
 
     yield

--- a/tests/unit/test_cli_args_coverage.py
+++ b/tests/unit/test_cli_args_coverage.py
@@ -141,13 +141,19 @@ class TestVaultHelpers:
 
         assert _get_vault() is mock_vault
 
-    @patch("secure_string_cipher.cli_args._prompt_password_with_validation")
+    @patch("secure_string_cipher.cli_args._prompt_master_password_to_set")
     @patch("builtins.input", return_value="y")
     @patch("secure_string_cipher.cli_args.PassphraseVault")
     def test_get_vault_initializes_missing_vault(
         self, mock_vault_cls, mock_input, mock_prompt
     ):
-        """Should initialize a missing vault when the user accepts."""
+        """Should initialize a missing vault when the user accepts.
+
+        Patches the master-password prompt specifically: initialization used
+        to go through the *data* password prompt, so supplying both a data
+        and a master password built the vault with the wrong one and left the
+        next unlock failing.
+        """
         mock_vault = MagicMock()
         mock_vault.vault_exists.return_value = False
         mock_vault_cls.return_value = mock_vault

--- a/tests/unit/test_cli_credential_sources.py
+++ b/tests/unit/test_cli_credential_sources.py
@@ -1,0 +1,229 @@
+"""Tests for non-interactive credential sources.
+
+Before these existed there was no `--password`, `--password-file` or
+environment variable, so v2 password mode and v2 combined mode could not be
+scripted at all, and anything using the vault needed an interactive master
+password. Piping worked only through CPython's degraded `getpass` fallback,
+which emits a warning and has no equivalent on Windows.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from secure_string_cipher import cli_args
+
+STRONG = "Str0ngScriptPass!2026"  # pragma: allowlist secret
+WEAK = "short"  # pragma: allowlist secret
+OTHER = "Different!Pass2026"  # pragma: allowlist secret
+
+
+def _password_file(directory: Path, value: str, *, mode: int = 0o600) -> Path:
+    path = directory / "pw.txt"
+    path.write_text(value + "\n")
+    path.chmod(mode)
+    return path
+
+
+def _args(**overrides: object) -> object:
+    import argparse
+
+    defaults = {
+        "quiet": False,
+        "no_color": False,
+        "debug": False,
+        "password_file": None,
+        "master_password_file": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestPasswordFile:
+    def test_password_file_supplies_the_password_without_prompting(
+        self, tmp_path: Path
+    ) -> None:
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        # No getpass patching: if this prompted, the test would hang or raise.
+        assert cli_args._prompt_password() == STRONG
+
+    def test_one_trailing_newline_is_removed(self, tmp_path: Path) -> None:
+        """A file written with `echo` has a newline the operator did not intend."""
+        path = tmp_path / "pw.txt"
+        path.write_bytes(STRONG.encode() + b"\n")
+        path.chmod(0o600)
+        cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert cli_args._prompt_password() == STRONG
+
+    def test_a_file_without_a_trailing_newline_works(self, tmp_path: Path) -> None:
+        path = tmp_path / "pw.txt"
+        path.write_bytes(STRONG.encode())
+        path.chmod(0o600)
+        cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert cli_args._prompt_password() == STRONG
+
+    def test_confirmation_is_skipped_for_a_supplied_password(
+        self, tmp_path: Path
+    ) -> None:
+        """There is nothing to confirm a file against."""
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password(confirm=True) == STRONG
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission semantics")
+    def test_group_or_other_readable_file_is_refused(self, tmp_path: Path) -> None:
+        """A password file is a bearer secret, held to the same standard as
+        a .ssckey: refused rather than used with a warning."""
+        path = _password_file(tmp_path, STRONG, mode=0o644)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+    def test_empty_file_is_refused_rather_than_read_as_an_empty_password(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "empty.txt"
+        path.write_bytes(b"")
+        path.chmod(0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_newline_only_file_is_refused(self, tmp_path: Path) -> None:
+        path = tmp_path / "nl.txt"
+        path.write_bytes(b"\n")
+        path.chmod(0o600)
+        with pytest.raises(SystemExit):
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+
+    def test_missing_file_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(
+                _args(password_file=str(tmp_path / "absent.txt"))
+            )
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+    def test_a_directory_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit):
+            cli_args._resolve_credential_sources(_args(password_file=str(tmp_path)))
+
+    def test_non_utf8_file_is_refused(self, tmp_path: Path) -> None:
+        path = tmp_path / "bin.txt"
+        path.write_bytes(b"\xff\xfe not text")
+        path.chmod(0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_oversized_file_is_refused_before_reaching_the_kdf(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "big.txt"
+        path.write_bytes(b"A" * (cli_args._MAX_PASSWORD_FILE_BYTES + 10))
+        path.chmod(0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    @pytest.mark.skipif(os.name != "posix", reason="requires symlink support")
+    def test_a_symlinked_password_file_is_refused(self, tmp_path: Path) -> None:
+        real = _password_file(tmp_path, STRONG)
+        link = tmp_path / "link.txt"
+        link.symlink_to(real)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(link)))
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+
+class TestEnvironmentVariables:
+    def test_ssc_password_supplies_the_password(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+        assert cli_args._prompt_password() == STRONG
+
+    def test_ssc_master_password_supplies_the_master_password(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+        assert cli_args._prompt_master_password() == STRONG
+
+    def test_an_empty_variable_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_PASSWORD", "")
+        cli_args._resolve_credential_sources(_args())
+        assert cli_args._password_source is None
+
+    def test_the_flag_wins_over_the_variable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Naming a file is the more deliberate act, and it stops a stale
+        exported variable quietly overriding the command line."""
+        monkeypatch.setenv("SSC_PASSWORD", OTHER)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password() == STRONG
+
+    def test_the_two_roles_are_independent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A data password and a vault master password are different secrets."""
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", OTHER)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password() == STRONG
+        assert cli_args._prompt_master_password() == OTHER
+
+
+class TestStrengthValidationStillApplies:
+    def test_a_weak_supplied_password_is_refused_not_retried(
+        self, tmp_path: Path
+    ) -> None:
+        """The interactive path loops until the password is strong enough.
+
+        A supplied source cannot be re-prompted, so it must fail rather than
+        loop forever.
+        """
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, WEAK)))
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._prompt_password_with_validation()
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_a_strong_supplied_password_is_accepted(self, tmp_path: Path) -> None:
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert cli_args._prompt_password_with_validation() == STRONG
+
+
+class TestParser:
+    def test_both_flags_are_accepted_and_default_to_none(self) -> None:
+        parser = cli_args.create_parser()
+        args = parser.parse_args(["encrypt", "-t", "x"])
+        assert args.password_file is None
+        assert args.master_password_file is None
+
+        args = parser.parse_args(
+            [
+                "--password-file",
+                "/p",
+                "--master-password-file",
+                "/m",
+                "encrypt",
+                "-t",
+                "x",
+            ]
+        )
+        assert args.password_file == "/p"
+        assert args.master_password_file == "/m"

--- a/tests/unit/test_cli_credential_sources.py
+++ b/tests/unit/test_cli_credential_sources.py
@@ -17,6 +17,7 @@ from secure_string_cipher import cli_args
 STRONG = "Str0ngScriptPass!2026"  # pragma: allowlist secret
 WEAK = "short"  # pragma: allowlist secret
 OTHER = "Different!Pass2026"  # pragma: allowlist secret
+CRLF_AND_CONTROL_Z = "ab\r\ncd\x1aef"  # pragma: allowlist secret
 
 
 def _password_file(directory: Path, value: str, *, mode: int = 0o600) -> Path:
@@ -338,3 +339,41 @@ class TestTheFileIsCheckedOnTheDescriptor:
         with pytest.raises(SystemExit) as excinfo:
             cli_args._resolve_credential_sources(_args(password_file=str(fifo)))
         assert excinfo.value.code == cli_args.EXIT_FILE_ERROR
+
+    @pytest.mark.skipif(not hasattr(os, "O_BINARY"), reason="Windows-only flag")
+    def test_the_file_is_opened_in_binary_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded: list[int] = []
+        real_open = os.open
+
+        def spy(path: object, flags: int, *args: object, **kwargs: object) -> int:
+            recorded.append(flags)
+            return real_open(path, flags, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "open", spy)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert recorded
+        assert all(flags & os.O_BINARY for flags in recorded)
+
+    def test_a_password_containing_cr_or_control_z_survives_verbatim(
+        self, tmp_path: Path
+    ) -> None:
+        """Text-mode translation would rewrite the file's actual bytes.
+
+        On Windows a descriptor opened without `O_BINARY` has CRLF collapsed
+        to LF and is truncated at a control-Z, so a password containing
+        either would be silently changed before this code ever saw it — and
+        the file would then decrypt nothing it had encrypted. Meaningful on
+        Windows; on POSIX it simply documents that only *one trailing* line
+        ending is removed.
+        """
+        password = CRLF_AND_CONTROL_Z
+        path = tmp_path / "pw.txt"
+        path.write_bytes(password.encode() + b"\n")
+        path.chmod(0o600)
+
+        cli_args._resolve_credential_sources(_args(password_file=str(path)))
+        assert cli_args._prompt_password() == password

--- a/tests/unit/test_cli_credential_sources.py
+++ b/tests/unit/test_cli_credential_sources.py
@@ -227,3 +227,114 @@ class TestParser:
         )
         assert args.password_file == "/p"
         assert args.master_password_file == "/m"
+
+
+class TestTheTwoMasterPasswordRolesAreDistinct:
+    """Setting a master password and using one are different roles.
+
+    A single supplied value read as both would let `vault change-password`
+    re-encrypt the vault with the password it already has and report a
+    successful rotation — an operator rotating a compromised password would
+    believe it had been replaced.
+    """
+
+    def test_change_password_refuses_to_reuse_the_supplied_current_password(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import argparse
+
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args.cmd_vault_change_password(argparse.Namespace())
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_the_new_password_has_its_own_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        monkeypatch.setenv("SSC_NEW_MASTER_PASSWORD", OTHER)
+        cli_args._resolve_credential_sources(_args())
+
+        assert cli_args._prompt_master_password() == STRONG
+        assert (
+            cli_args._prompt_master_password_to_set(
+                "unused: ",
+                supplied=cli_args._new_master_password_source,
+                source_flag="",
+            )
+            == OTHER
+        )
+
+    def test_a_weak_password_being_set_fails_rather_than_prompting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SSC_NEW_MASTER_PASSWORD", WEAK)
+        cli_args._resolve_credential_sources(_args())
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._prompt_master_password_to_set(
+                "unused: ",
+                supplied=cli_args._new_master_password_source,
+                source_flag="SSC_NEW_MASTER_PASSWORD",
+            )
+        assert excinfo.value.code == cli_args.EXIT_INPUT_ERROR
+
+    def test_vault_initialisation_uses_the_master_source_not_the_data_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With both files supplied, initialising from the data password
+        would leave the very next unlock failing against the master one."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("SSC_PASSWORD", OTHER)
+        monkeypatch.setenv("SSC_MASTER_PASSWORD", STRONG)
+        cli_args._resolve_credential_sources(_args())
+        monkeypatch.setattr("builtins.input", lambda: "y")
+
+        vault = cli_args._get_vault()
+        assert vault.vault_exists()
+        # Proof of which password the vault was built with: the master one
+        # opens it, and a store/retrieve round-trip completes.
+        vault.store_passphrase("label", "value", STRONG)
+        assert vault.retrieve_passphrase("label", STRONG) == "value"
+
+
+class TestTheFileIsCheckedOnTheDescriptor:
+    """The permission and type checks must apply to what was opened.
+
+    Checking the path and then opening it leaves a window in which another
+    local process can replace the final component, so the checks would
+    describe the old inode while the read consumes a substituted one. The
+    race is not deterministically reproducible from a test, so these assert
+    the mechanism that closes it instead of staging a fake reproduction.
+    """
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="POSIX-only flag")
+    def test_the_file_is_opened_with_o_nofollow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded: list[int] = []
+        real_open = os.open
+
+        def spy(path: object, flags: int, *args: object, **kwargs: object) -> int:
+            recorded.append(flags)
+            return real_open(path, flags, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "open", spy)
+        cli_args._resolve_credential_sources(
+            _args(password_file=str(_password_file(tmp_path, STRONG)))
+        )
+        assert recorded, "the password file was not opened through os.open"
+        assert all(flags & os.O_NOFOLLOW for flags in recorded)
+
+    @pytest.mark.skipif(os.name != "posix", reason="requires mkfifo")
+    def test_a_fifo_is_refused_by_the_descriptor_type_check(
+        self, tmp_path: Path
+    ) -> None:
+        """A named pipe is not a file to read a password from, and reading
+        one would block or return an attacker-fed value."""
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo, 0o600)
+        with pytest.raises(SystemExit) as excinfo:
+            cli_args._resolve_credential_sources(_args(password_file=str(fifo)))
+        assert excinfo.value.code == cli_args.EXIT_FILE_ERROR


### PR DESCRIPTION
Closes **#94**. Replaces **#119**, which GitHub auto-closed (and will not reopen) when its base branch `feat/v2-app-layer` was deleted on #118's merge — same branch, same work, now targeting `main` directly. **The three review findings on #119 are fixed here; their threads are resolved there with the reasoning.**

> The branch was also linearised: #118's commits reached `main` as a squash, so replaying them would have duplicated the content. Verified the rebuilt branch's tree is byte-identical to what #119 last had (`git diff` between the two is empty), so nothing was lost in the rewrite.

## Review findings from #119, all confirmed and fixed

| | Finding | Verdict |
|---|---|---|
| P1 | `vault change-password` read one supplied master password as **both** old and new | **Real, and the worst of the three** — it re-encrypted the vault with the password it already had and printed `✓ Master password changed.` An operator rotating a compromised password would have believed it replaced. Setting and using a master password are now separate roles with separate sources (`--new-master-password-file` / `SSC_NEW_MASTER_PASSWORD`); supplying only the current one is refused rather than aliased, and a new password equal to the old one is refused too. |
| P1 | Vault initialisation consumed the **data**-password source | **Real** — `--master-password-file` alone still prompted, and supplying both files built the vault with the data password, leaving the next unlock failing. Now uses the master source. The existing coverage test patched the data-password prompt, which is how it went unnoticed; it now patches the master one and says why. |
| P2 | Password file checked by path, then opened | **Real TOCTOU** — the checks described the pre-`open` inode. Now `O_NOFOLLOW` + `fstat`, matching `v2/keyfile.py`'s loader, which already did this correctly for the other bearer secret. The inconsistency was mine, not a gap in the codebase's conventions. |

Each fix was falsified individually: reverting it fails exactly the test written for it.

---


## Why now, and why before #95

There was no non-interactive credential source at all. The only options were `--vault` (which itself needs an interactive master password) and `--key-file` (v1 only). So:

- **v2 password mode** could not be scripted
- **v2 combined mode** could not be scripted
- every vault or key command required a person at a terminal

Piping worked only through CPython's degraded `getpass` fallback, which prints `GetPassWarning: Can not control echo` and has no Windows equivalent.

This has to land **before #95**. You chose default-on key-status enforcement, which introduces a master-password prompt into `ssc encrypt --with key:X` — currently the one scriptable v2 path. Without an escape hatch first, #95 would break automation the moment it lands.

## Two roles, deliberately not one flag

```
--password-file / SSC_PASSWORD                the data password
--master-password-file / SSC_MASTER_PASSWORD  the vault master password
```

Kept separate rather than overloading a single flag — we have just spent effort *removing* an overload from `--vault` (#95), so adding a new one would be a poor trade.

**The flag wins over the variable.** Naming a file is the more deliberate act, and it stops a stale exported value quietly overriding the command line. Verified cryptographically rather than by inspection: a token encrypted with the file's password fails to decrypt when only the variable is set, and succeeds with the file.

## Safety

A password file is the same kind of secret as a `.ssckey`, so it is held to the same standard:

| condition | result |
|---|---|
| group/other-readable (POSIX) | **refused** — `chmod 600` advised in the message |
| reached through a symlink | refused |
| not a regular file / missing / a directory | refused |
| empty or newline-only | refused, rather than read as an empty password |
| larger than 65536 bytes | refused before reaching Argon2id (the same bound v2 applies) |
| not valid UTF-8 | refused |

One trailing line ending is removed via the same helper the stdin path uses, so the two agree — a file written with `echo` has one and the operator does not intend it.

Confirmation is skipped for a supplied password (nothing to confirm against). Where a *new* password is being set, strength validation still applies but **fails rather than looping**, since a file cannot be re-prompted.

The README notes that a file is preferable to a variable: on some systems a process's environment is readable by other processes of the same user, and variables are easily captured in shell history and CI logs.

## Verification

The three previously-impossible flows, confirmed by hand end to end:

```
ssc --password-file pw.txt encrypt -f doc.txt --with password           -> 0
SSC_PASSWORD=... ssc encrypt -f doc.txt --with password                 -> 0
ssc --password-file pw.txt encrypt -f doc.txt \
    --with password --with key:ci --require all                         -> 0
```

Plus every rejection above, checked live. 20 new tests; full suite **1673 passing**; `ruff`, `mypy src` and the sensitive-output guard clean.

`tests/conftest.py`'s autouse fixture now restores the new globals: a leaked `_password_source` would make a later test appear to succeed without prompting, hiding the behaviour it meant to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
