### PR TITLE
feat: declare the v2 API public, and deprecate CLI internals at the root

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "src/secure_string_cipher/cli_args.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 635
+        "line_number": 636
       }
     ],
     "tests/fixtures/v2/combined_grant_header.json": [
@@ -546,5 +546,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-12T22:37:40Z"
+  "generated_at": "2026-09-12T23:24:04Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
   container formats sharing one namespace would make `encrypt_file`
   ambiguous. Anything reached through a deeper path (`v2.envelope`,
   `v2.vault_service`) remains internal and may change in a minor release.
+  `v2.app` also gained `header_from_container` / `header_from_stream`, the
+  binary counterparts to `header_from_armour`: `required_credential` needs a
+  header, so without a public way to read one from a `.ssc` file the layer
+  could not do its main job without importing `v2.header_parser` — which the
+  same change declares internal. `cli_args.py` now goes through them too, so
+  the CLI stops being a counter-example to its own boundary.
 
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@
   `O_BINARY` so that Windows cannot collapse a CRLF or truncate at a
   control-Z inside a password before it is read.
 
+- **`secure_string_cipher.v2` is now declared public, semver-covered API.**
+  It had no stated stability tier at all: the package root's `__all__` was 50
+  v1 entries, `hasattr(secure_string_cipher, "v2")` was `False`, and
+  `docs/API.md` nonetheless documented v2 usage and told readers to import
+  `compute_fingerprint` from `secure_string_cipher.v2.key_identity` — a
+  private third-level module. So there was nothing coherent to freeze. The
+  subpackage is now imported at the root (`from secure_string_cipher import
+  v2`) and listed in its `__all__`; `v2.__all__` grew from 10 to 18 to cover
+  what the documented examples actually need, including `compute_fingerprint`,
+  `load_keyfile`/`save_keyfile`, `KeyStatus`/`KeyStorageMode` and the `app`
+  submodule. It is deliberately *not* flattened into the root namespace: two
+  container formats sharing one namespace would make `encrypt_file`
+  ambiguous. Anything reached through a deeper path (`v2.envelope`,
+  `v2.vault_service`) remains internal and may change in a minor release.
+
 - **`secure_string_cipher.v2.app` — a reusable application layer for v2
   credentials and managed-key policy.** Key resolution, key-status policy,
   header→requirement mapping, armoured-header parsing and credential
@@ -60,6 +75,27 @@
   in `docs/API.md`, that `.enc` (v1 default) vs `.ssc` (v2 default) are
   human-facing output-filename conventions only — `ssc decrypt` reads a
   file's magic bytes, never its extension, to decide which format it is.
+
+### Deprecated
+
+- **`colorize`, `ProgressBar` and `main` in the package root.** These are
+  internals of the command-line interface, not library API, and they will be
+  removed in 3.0.0; importing one now emits a `DeprecationWarning` and still
+  returns the object. `main` is the one to read twice: the export is
+  `secure_string_cipher.cli:main`, the *interactive menu's* entry point, while
+  the installed `ssc` command is `secure_string_cipher.cli_args:main` — a
+  different function under the same name. They stay in `__all__` until the
+  major bump, since removing them now would break `from secure_string_cipher
+  import *` in a minor release. A side effect of serving them lazily:
+  importing the package no longer loads the interactive CLI module, which it
+  did solely to satisfy `main`.
+
+  Deliberately **not** deprecated, though an audit of the surface might
+  suggest otherwise: `add_timing_jitter`, `PersistentRateLimiter`,
+  `get_global_limiter`, `AuditLogger` and `get_audit_logger`. Each is usable
+  on its own terms by a program embedding this library — a caller running its
+  own passphrase attempts has the same reason to rate-limit them as the CLI
+  does. Being used by the CLI does not make something a CLI internal.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,27 @@ if has_secure_memory():
     print("Using libsodium for secure memory zeroing")
 ```
 
+### V2 Managed-Key Containers
+
+The `.ssc` container format lives in the `v2` submodule, which is public,
+semver-covered API alongside the exports above:
+
+```python
+from pathlib import Path
+
+from secure_string_cipher import v2
+
+credential = v2.PasswordCredential("MySecurePass123!")
+v2.encrypt_v2_file(Path("report.pdf"), Path("report.pdf.ssc"), credential=credential)
+```
+
+A managed-key credential needs the key's 32-byte secret and its fingerprint;
+`v2.load_keyfile` reads both from a `.ssckey` file. `v2.app` is the layer above
+these primitives — it resolves a key reference, reports which credential an
+object requires, and applies lifecycle policy, without prompting or exiting, so
+an interface can use it directly. See [docs/API.md](docs/API.md#v2-encryption)
+for the full surface and where the public/internal boundary sits.
+
 ## Security
 
 | Component | Implementation | Details |

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,11 +28,36 @@ illustration only.
 | Security and memory | `check_password_strength`, `constant_time_compare`, `add_timing_jitter`, `SecureString`, `SecureBytes`, `secure_wipe`, `has_secure_memory` |
 | Rate limiting | `RateLimiter`, `PersistentRateLimiter`, `rate_limited`, `get_global_limiter` |
 | Audit logging | `AuditLogger`, `AuditEvent`, `AuditLevel`, `get_audit_logger`, `audit_event`, `audit_auth_failure`, `audit_rate_limit` |
-| Terminal and CLI | `colorize`, `secure_overwrite`, `ProgressBar`, `main` |
+| Secure deletion | `secure_overwrite` |
+| V2 container format | `v2` (a submodule — see [V2 Encryption](#v2-encryption)) |
+| **Deprecated**, removal in 3.0.0 | `colorize`, `ProgressBar`, `main` |
 
-The v2 managed-key implementation lives in the secure_string_cipher.v2
-subpackage. Its symbols are importable from that subpackage only and are not
-package-root exports, so they are intentionally absent from the table above.
+### Stability
+
+Everything in the table above is public API covered by this package's version:
+it will not change incompatibly outside a major version bump. The same holds
+for `secure_string_cipher.v2` and `secure_string_cipher.v2.app` — see
+[V2 Encryption](#v2-encryption) for where that boundary sits inside the
+subpackage. Anything not named in one of those three `__all__` lists is
+internal, whatever its import path looks like.
+
+### Deprecated exports
+
+`colorize`, `ProgressBar` and `main` are internals of the command-line
+interface rather than library API, and they still import with a
+`DeprecationWarning`; they will be removed in 3.0.0. `main` is the one worth
+reading twice: it is `secure_string_cipher.cli:main`, the *interactive menu's*
+entry point, while the installed `ssc` command is
+`secure_string_cipher.cli_args:main` — a different function under the same
+name. If you invoke the CLI programmatically, name the module you mean.
+
+Deliberately **not** deprecated, though a reader might expect them to be:
+`add_timing_jitter`, `PersistentRateLimiter`, `get_global_limiter`,
+`AuditLogger` and `get_audit_logger`. They are reachable from the CLI, but
+each is usable on its own terms by a program that embeds this library — a
+caller doing its own passphrase attempts has the same reason to rate-limit
+them, and one handling secrets has the same reason to record an audit trail.
+Being used by the CLI does not make something a CLI internal.
 
 ## Core Encryption
 
@@ -269,6 +294,18 @@ authoritative for both versions.
 
 The `secure_string_cipher.v2` submodule adds a new `.ssc` container format
 with AEAD DEK wrapping, alongside (not replacing) the V4/V5 legacy format.
+
+**It is public, semver-covered API**, at two levels: the names in
+`secure_string_cipher.v2.__all__` (the primitives below) and those in
+`secure_string_cipher.v2.app.__all__` (the layer above them — key resolution,
+credential requirements, lifecycle policy, no prompting and no exiting). A
+deeper path such as `v2.envelope` or `v2.vault_service` is internal and may
+change in a minor release; needing something from one of those is a sign this
+surface is missing something, so it is worth raising rather than importing.
+
+`v2` is not flattened into the package root: the root namespace is v1's API,
+and two `encrypt_file`-shaped functions in one namespace would be ambiguous to
+a reader. Import the submodule — `from secure_string_cipher import v2`.
 Each `.ssc` object carries exactly **one** access grant — there is no
 multi-grant access control. That grant can require a password and a managed
 key together via `CombinedCredential`; it cannot be satisfied by either alone,
@@ -280,11 +317,11 @@ from pathlib import Path
 from secure_string_cipher.v2 import (
     encrypt_v2_file,
     decrypt_v2_file,
+    compute_fingerprint,
     PasswordCredential,
     KeyCredential,
     CombinedCredential,
 )
-from secure_string_cipher.v2.key_identity import compute_fingerprint
 
 # Single password
 cred = PasswordCredential("MySecurePass123!")

--- a/docs/API.md
+++ b/docs/API.md
@@ -306,6 +306,38 @@ surface is missing something, so it is worth raising rather than importing.
 `v2` is not flattened into the package root: the root namespace is v1's API,
 and two `encrypt_file`-shaped functions in one namespace would be ambiguous to
 a reader. Import the submodule — `from secure_string_cipher import v2`.
+
+`v2.app` is what an interface should build on. It reads a container's header,
+says which credential that container's grant requires, resolves a key
+reference to a keyfile, and applies managed-key lifecycle policy — raising
+typed errors under a `V2AppError` base, never prompting and never exiting:
+
+```python
+from pathlib import Path
+
+from secure_string_cipher.v2 import app, decrypt_v2_file
+
+passphrase = "MySecurePass123!"  # pragma: allowlist secret - documentation example
+
+header = app.header_from_container(Path("report.pdf.ssc"))
+requirement = app.required_credential(header)
+
+if requirement.needs_managed_key:
+    assert requirement.key_fingerprint is not None
+    key_data = app.KeyResolver().resolve(requirement.key_fingerprint)
+else:
+    key_data = None
+
+credential = app.build_credential(
+    requirement,
+    password=passphrase if requirement.needs_password else None,  # pragma: allowlist secret
+    key_data=key_data,
+)
+decrypt_v2_file(Path("report.pdf.ssc"), credential=credential)
+```
+
+`header_from_armour` is the same entry point for an armoured text message;
+the header is framed differently in each, which is why there are two.
 Each `.ssc` object carries exactly **one** access grant — there is no
 multi-grant access control. That grant can require a password and a managed
 key together via `CombinedCredential`; it cannot be satisfied by either alone,

--- a/src/secure_string_cipher/__init__.py
+++ b/src/secure_string_cipher/__init__.py
@@ -4,6 +4,7 @@ secure_string_cipher - Core encryption functionality
 
 from importlib.metadata import PackageNotFoundError, version
 
+from . import v2
 from .audit_log import (
     AuditEvent,
     AuditLevel,
@@ -13,7 +14,6 @@ from .audit_log import (
     audit_rate_limit,
     get_audit_logger,
 )
-from .cli import main
 from .config import (
     VaultSettings,
     load_vault_settings,
@@ -58,7 +58,7 @@ from .timing_safe import (
     check_password_strength,
     constant_time_compare,
 )
-from .utils import ProgressBar, colorize, secure_overwrite
+from .utils import secure_overwrite
 
 try:
     __version__ = version("secure-string-cipher")
@@ -123,9 +123,58 @@ __all__ = [
     "audit_event",
     "audit_auth_failure",
     "audit_rate_limit",
-    # CLI utilities
-    "colorize",
     "secure_overwrite",
+    # The v2 container format, as a submodule rather than flattened here
+    "v2",
+    # Deprecated: terminal presentation and the interactive menu's entry
+    # point. Still importable, with a warning; see _DEPRECATED_EXPORTS.
+    "colorize",
     "ProgressBar",
     "main",
 ]
+
+# Terminal presentation and an application entry point are not part of what a
+# string-encryption library offers, and `main` is the worse problem: it is
+# `cli.main` (the interactive menu), while the installed `ssc` command is
+# `cli_args:main` — two different functions reachable under one name. Keeping
+# them importable, with a warning, until the next major version; removing them
+# now would be a breaking change in a minor release.
+#
+# They are served lazily so that importing this package no longer pulls in the
+# interactive CLI module, which it did solely to satisfy `main`.
+_DEPRECATED_EXPORTS = {
+    "colorize": ("secure_string_cipher.utils", "colorize"),
+    "ProgressBar": ("secure_string_cipher.utils", "ProgressBar"),
+    "main": ("secure_string_cipher.cli", "main"),
+}
+
+
+def __getattr__(name: str) -> object:
+    """Serve a deprecated export, warning at the point of use.
+
+    Reached only for names this module does not define, so the warning fires
+    for exactly the deprecated set — including via ``import *``, which
+    consults ``__all__`` and so comes back through here.
+    """
+    target = _DEPRECATED_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+    import warnings
+
+    module_name, attribute = target
+    warnings.warn(
+        f"secure_string_cipher.{name} is deprecated and will be removed in "
+        f"3.0.0. It is an internal of the command-line interface, not part of "
+        f"the library's API"
+        + (
+            "; the installed `ssc` command is secure_string_cipher.cli_args:"
+            "main, which is a different function from this one"
+            if name == "main"
+            else f". Import it from {module_name} if you still need it"
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return getattr(importlib.import_module(module_name), attribute)

--- a/src/secure_string_cipher/__init__.py
+++ b/src/secure_string_cipher/__init__.py
@@ -3,6 +3,7 @@ secure_string_cipher - Core encryption functionality
 """
 
 from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING
 
 from . import v2
 from .audit_log import (
@@ -147,6 +148,16 @@ _DEPRECATED_EXPORTS = {
     "ProgressBar": ("secure_string_cipher.utils", "ProgressBar"),
     "main": ("secure_string_cipher.cli", "main"),
 }
+
+if TYPE_CHECKING:
+    # This package ships py.typed, so a type checker's view of these names is
+    # part of what "still works until 3.0.0" means. Without these imports the
+    # lazy loader gives them the static type `object`, and a typed consumer
+    # calling `main()` or annotating with `ProgressBar` fails to check *now* —
+    # which would make the deprecation a break rather than a warning. The
+    # imports cost nothing at runtime, so the interactive CLI stays unloaded.
+    from .cli import main
+    from .utils import ProgressBar, colorize
 
 
 def __getattr__(name: str) -> object:

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -70,6 +70,7 @@ from .v2.app import (
     VaultUnlockFailed,
     build_credential,
     header_from_armour,
+    header_from_container,
     required_credential,
 )
 from .v2.decrypt import decrypt_v2_file, decrypt_v2_text
@@ -1182,8 +1183,6 @@ def _cmd_decrypt_v2(
     args: argparse.Namespace, is_message: bool, rate_identifier: str = ""
 ) -> int:
 
-    from .v2.header_parser import parse_header_stream
-
     if is_message:
         try:
             header = header_from_armour(args.text)
@@ -1208,9 +1207,8 @@ def _cmd_decrypt_v2(
     # File decrypt V2 (real binary SSC2 container: magic + length prefix).
     filepath = Path(args.file)
     try:
-        with open(filepath, "rb") as f:
-            header, _ = parse_header_stream(f)
-    except (OSError, PermissionError):
+        header = header_from_container(filepath)
+    except OSError:
         _exit_error(EXIT_FILE_ERROR, "File error.")
     except Exception:
         _cli_limiter.record_attempt("decrypt_file", rate_identifier, success=False)

--- a/src/secure_string_cipher/cli_args.py
+++ b/src/secure_string_cipher/cli_args.py
@@ -1064,7 +1064,7 @@ def _resolve_v2_key_source(key_ref: str) -> KeyFileData:
     its typed errors into CLI exits.
     """
     try:
-        return KeyResolver().resolve(key_ref)
+        key_data = KeyResolver().resolve(key_ref)
     except KeyFileUnreadable:
         _exit_error(EXIT_FILE_ERROR, "Could not load key file.")
     except KeyDirectoryUnreadable as error:
@@ -1079,6 +1079,7 @@ def _resolve_v2_key_source(key_ref: str) -> KeyFileData:
             "Key not found: provide a .ssckey path or a fingerprint/key-id "
             f"present in {keys_dir}.",
         )
+    return key_data
 
 
 def _get_v2_password(args: argparse.Namespace) -> str:

--- a/src/secure_string_cipher/v2/__init__.py
+++ b/src/secure_string_cipher/v2/__init__.py
@@ -15,11 +15,11 @@ v1's API, and flattening two container formats into one namespace would make
     from secure_string_cipher import v2
     from secure_string_cipher.v2 import encrypt_v2_file, PasswordCredential
 
-The ``app`` submodule is the layer above these primitives: it resolves a key
-reference to a keyfile, decides what credential an object requires, and
-enforces managed-key lifecycle policy, without prompting or exiting. Use it
-when building an interface; use the primitives here when you already hold a
-credential.
+The ``app`` submodule is the layer above these primitives: it reads a
+container's header (binary or armoured), resolves a key reference to a
+keyfile, decides what credential an object requires, and enforces managed-key
+lifecycle policy — without prompting or exiting. Use it when building an
+interface; use the primitives here when you already hold a credential.
 """
 
 from . import app

--- a/src/secure_string_cipher/v2/__init__.py
+++ b/src/secure_string_cipher/v2/__init__.py
@@ -1,11 +1,28 @@
-"""SSC v2 managed-key implementation package.
+"""SSC v2 managed-key container format — public, semver-covered API.
 
-This package is introduced as a parallel implementation path for the v2
-managed-key architecture. It exports the v2 dataclasses and helpers listed
-in ``__all__``; these symbols are available under ``secure_string_cipher.v2``
-and are not re-exported from the package root.
+Everything listed in ``__all__`` here, and in ``secure_string_cipher.v2.app``,
+is public API covered by this package's version guarantees: it will not change
+incompatibly outside a major version bump. Anything reached through a deeper
+module path (``v2.envelope``, ``v2.keyfile``, ``v2.vault_service`` …) is
+internal, and may change in a minor release — so if you find yourself needing
+something from one of those, that is worth raising as an issue rather than
+importing, because it means this surface is missing something.
+
+``v2`` is not re-exported into the package root's flat namespace: the root is
+v1's API, and flattening two container formats into one namespace would make
+``encrypt_file`` ambiguous to a reader. Import the submodule instead::
+
+    from secure_string_cipher import v2
+    from secure_string_cipher.v2 import encrypt_v2_file, PasswordCredential
+
+The ``app`` submodule is the layer above these primitives: it resolves a key
+reference to a keyfile, decides what credential an object requires, and
+enforces managed-key lifecycle policy, without prompting or exiting. Use it
+when building an interface; use the primitives here when you already hold a
+credential.
 """
 
+from . import app
 from .decrypt import decrypt_v2_file, decrypt_v2_text
 from .encrypt import (
     CombinedCredential,
@@ -15,18 +32,33 @@ from .encrypt import (
     encrypt_v2_file,
     encrypt_v2_text,
 )
-from .envelope import V2Header
+from .envelope import GrantType, V2Header
+from .key_identity import KeyStatus, KeyStorageMode, compute_fingerprint
+from .keyfile import KeyFileData, load_keyfile, save_keyfile
 from .vault_service import V2VaultService
 
 __all__ = [
+    # Encrypt / decrypt
     "decrypt_v2_file",
     "decrypt_v2_text",
     "encrypt_v2_file",
     "encrypt_v2_text",
+    # Credentials
     "CombinedCredential",
     "KeyCredential",
     "PasswordCredential",
     "V2Credential",
+    # Managed keys and their identity
+    "KeyFileData",
+    "KeyStatus",
+    "KeyStorageMode",
+    "compute_fingerprint",
+    "load_keyfile",
+    "save_keyfile",
+    # Container metadata and key lifecycle
+    "GrantType",
     "V2Header",
     "V2VaultService",
+    # The application layer
+    "app",
 ]

--- a/src/secure_string_cipher/v2/app.py
+++ b/src/secure_string_cipher/v2/app.py
@@ -11,6 +11,13 @@ Nothing here performs interactive input or exits the process. Callers supply
 credentials and receive either a value or a typed exception, and decide for
 themselves how to prompt, render and exit.
 
+Both container shapes are reachable from here: `header_from_container` /
+`header_from_stream` for the binary `.ssc` framing and `header_from_armour`
+for an armoured message. That matters because `required_credential` needs a
+header, so without a public way to read one from a file the layer could not
+do its primary job without reaching into `v2.header_parser` — which is
+internal.
+
 Deliberately *not* included: obtaining a password. Where a password comes
 from — a prompt, a vault entry, a file, an environment variable — is an
 interface concern, so it stays with the caller. This module only says which
@@ -22,6 +29,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import BinaryIO
 
 from secure_string_cipher.v2.encrypt import (
     CombinedCredential,
@@ -50,6 +58,8 @@ __all__ = [
     "build_credential",
     "default_keys_dir",
     "header_from_armour",
+    "header_from_container",
+    "header_from_stream",
     "required_credential",
 ]
 
@@ -201,6 +211,43 @@ def header_from_armour(armoured_text: str) -> V2Header:
         return validate_v2_header(header_dict, raw_bytes)
     except Exception as error:
         raise MalformedContainer(error) from error
+
+
+def header_from_stream(stream: BinaryIO) -> V2Header:
+    """Read and validate the protected header from a binary `SSC2` stream.
+
+    The counterpart to `header_from_armour` for the format a `.ssc` *file*
+    actually uses. Both exist because the header is framed differently in
+    each: binary containers carry `SSC2` plus a length prefix, armoured
+    messages carry Base64'd canonical JSON.
+
+    The stream is left positioned after the header, so a caller that is about
+    to decrypt does not have to re-open the file.
+
+    Raises `MalformedContainer`, deliberately without detail: the caller is
+    about to decide whether to attempt decryption, and a parse failure should
+    not describe the input back.
+    """
+    from secure_string_cipher.v2.header_parser import parse_header_stream
+
+    try:
+        header, _ = parse_header_stream(stream)
+    except Exception as error:
+        raise MalformedContainer(error) from error
+    return header
+
+
+def header_from_container(path: Path) -> V2Header:
+    """Read the protected header from a `.ssc` file on disk.
+
+    An `OSError` from opening the file is deliberately *not* wrapped: "this
+    file is unreadable" and "this file is not a v2 container" call for
+    different handling by the caller, and collapsing them into
+    `MalformedContainer` would report a permissions problem as a corrupt
+    object.
+    """
+    with open(path, "rb") as stream:
+        return header_from_stream(stream)
 
 
 def required_credential(header: V2Header) -> GrantRequirement:

--- a/tests/unit/test_documentation.py
+++ b/tests/unit/test_documentation.py
@@ -32,11 +32,18 @@ def test_public_python_examples_are_syntactically_valid(relative_path: Path) -> 
 
 
 def test_api_index_covers_every_package_root_export() -> None:
-    """Make additions or removals from the public API update its index."""
+    """Make additions or removals from the public API update its index.
+
+    Reads the table rows only, not the whole section: prose explaining the
+    table is free to mention a backticked identifier (a deprecation notice
+    naming `DeprecationWarning`, say) without that counting as a documented
+    export, which would otherwise make this fail for writing about the API.
+    """
     document = (REPOSITORY_ROOT / "docs" / "API.md").read_text(encoding="utf-8")
-    table = document.split("## Public API at a glance", maxsplit=1)[1].split(
+    section = document.split("## Public API at a glance", maxsplit=1)[1].split(
         "## Core Encryption", maxsplit=1
     )[0]
-    documented = set(re.findall(r"`([A-Za-z_][A-Za-z0-9_]*)`", table))
+    rows = [line for line in section.splitlines() if line.lstrip().startswith("|")]
+    documented = set(re.findall(r"`([A-Za-z_][A-Za-z0-9_]*)`", "\n".join(rows)))
 
     assert documented == set(secure_string_cipher.__all__)

--- a/tests/unit/test_v2_app_layer.py
+++ b/tests/unit/test_v2_app_layer.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from secure_string_cipher.v2 import app
 from secure_string_cipher.v2.app import (
     CredentialRequirement,
     GrantRequirement,
@@ -319,3 +320,54 @@ class TestLayerIsHeadless:
 
         assert isinstance(credential, KeyCredential)
         assert credential.key_fingerprint == data.fingerprint
+
+
+class TestHeaderInspection:
+    """Both container shapes must be readable from the public layer.
+
+    `required_credential` needs a `V2Header`, so if the only public way to
+    obtain one covered armoured text, an interface handling `.ssc` *files* —
+    the primary format — would have to import `v2.header_parser`, which the
+    package declares internal. The layer would then be unable to do its main
+    job without violating its own API boundary.
+    """
+
+    def _password_container(self, tmp_path: Path) -> Path:
+        from secure_string_cipher.v2 import PasswordCredential, encrypt_v2_file
+
+        source = tmp_path / "doc.txt"
+        source.write_bytes(b"contents" * 100)
+        destination = tmp_path / "doc.txt.ssc"
+        encrypt_v2_file(source, destination, credential=PasswordCredential(PASSWORD))
+        return destination
+
+    def test_a_binary_container_yields_the_requirement_its_grant_names(
+        self, tmp_path: Path
+    ) -> None:
+        header = app.header_from_container(self._password_container(tmp_path))
+        requirement = app.required_credential(header)
+        assert requirement.requirement is app.CredentialRequirement.PASSWORD
+
+    def test_the_stream_is_left_positioned_after_the_header(
+        self, tmp_path: Path
+    ) -> None:
+        """So a caller about to decrypt need not re-open the file."""
+        path = self._password_container(tmp_path)
+        with open(path, "rb") as stream:
+            app.header_from_stream(stream)
+            assert stream.tell() > 0
+            assert stream.tell() < path.stat().st_size
+
+    def test_a_non_container_is_reported_as_malformed(self, tmp_path: Path) -> None:
+        path = tmp_path / "not-a-container.ssc"
+        path.write_bytes(b"just some bytes that are not SSC2 framed")
+        with pytest.raises(app.MalformedContainer):
+            app.header_from_container(path)
+
+    def test_an_unreadable_file_raises_oserror_not_malformed(
+        self, tmp_path: Path
+    ) -> None:
+        """ "Cannot read this file" and "this is not a container" need
+        different handling, so they must not collapse into one error."""
+        with pytest.raises(OSError):
+            app.header_from_container(tmp_path / "absent.ssc")

--- a/tests/unit/test_v2_package.py
+++ b/tests/unit/test_v2_package.py
@@ -1,8 +1,18 @@
-"""Tests for the v2 package skeleton."""
+"""Tests for the v2 package's declared public surface.
+
+`secure_string_cipher.v2` is public, semver-covered API, so its `__all__` is
+a promise rather than a convenience. These tests make a change to that promise
+deliberate: adding or removing a name fails here first.
+"""
 
 import importlib.resources
+import warnings
 
+import pytest
+
+import secure_string_cipher
 import secure_string_cipher.v2 as v2
+import secure_string_cipher.v2.app as v2_app
 
 INTENDED_V2_EXPORTS = {
     "decrypt_v2_file",
@@ -13,19 +23,96 @@ INTENDED_V2_EXPORTS = {
     "KeyCredential",
     "PasswordCredential",
     "V2Credential",
+    "KeyFileData",
+    "KeyStatus",
+    "KeyStorageMode",
+    "compute_fingerprint",
+    "load_keyfile",
+    "save_keyfile",
+    "GrantType",
     "V2Header",
     "V2VaultService",
+    "app",
 }
 
+DEPRECATED_ROOT_EXPORTS = {"colorize", "ProgressBar", "main"}
 
-def test_v2_package_imports_without_public_api():
-    """The v2 package should export exactly its intended public surface."""
+
+def test_v2_exports_exactly_its_intended_surface():
     assert set(v2.__all__) == INTENDED_V2_EXPORTS
 
 
+def test_every_declared_export_actually_resolves():
+    """A name in `__all__` that does not import is a broken promise."""
+    for name in (*v2.__all__, *v2_app.__all__):
+        source = v2_app if name in v2_app.__all__ else v2
+        assert hasattr(source, name), f"{name} is declared but missing"
+
+
+def test_v2_is_reachable_from_the_package_root():
+    """Documented as `from secure_string_cipher import v2`, so that must work."""
+    assert secure_string_cipher.v2 is v2
+    assert "v2" in secure_string_cipher.__all__
+
+
+def test_the_fingerprint_helper_needs_no_third_level_import():
+    """docs/API.md's example imports it from `v2` directly.
+
+    It previously reached into `v2.key_identity`, which told readers that a
+    private module was part of the API.
+    """
+    assert v2.compute_fingerprint(b"\x01" * 32).startswith("ssc-k1-")
+
+
 def test_v2_package_exists_in_source_tree():
-    """The v2 package should live under secure_string_cipher."""
     package_init = importlib.resources.files("secure_string_cipher.v2").joinpath(
         "__init__.py"
     )
     assert package_init.is_file()
+
+
+class TestDeprecatedRootExports:
+    def test_each_one_warns_but_still_works(self):
+        for name in DEPRECATED_ROOT_EXPORTS:
+            with pytest.warns(DeprecationWarning, match=name):
+                assert getattr(secure_string_cipher, name) is not None
+
+    def test_they_stay_in_all_until_the_major_bump(self):
+        """Removing them from `__all__` would break `import *` silently.
+
+        The warning is the deprecation signal; the removal is 3.0.0's.
+        """
+        assert set(secure_string_cipher.__all__) >= DEPRECATED_ROOT_EXPORTS
+
+    def test_importing_the_package_no_longer_loads_the_interactive_cli(self):
+        """`main` was the only reason the root imported `cli`.
+
+        Asserted on a subprocess, because this process has almost certainly
+        imported `cli` already through some other test.
+        """
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys, secure_string_cipher; "
+                "print('secure_string_cipher.cli' in sys.modules)",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.strip() == "False"
+
+    def test_an_unknown_attribute_still_raises_attribute_error(self):
+        """The lazy loader must not turn typos into something else."""
+        with pytest.raises(AttributeError, match="no attribute"):
+            _ = secure_string_cipher.definitely_not_exported
+
+    def test_a_live_export_does_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert secure_string_cipher.encrypt_text is not None
+            assert secure_string_cipher.secure_overwrite is not None

--- a/tests/unit/test_v2_package.py
+++ b/tests/unit/test_v2_package.py
@@ -93,13 +93,12 @@ class TestDeprecatedRootExports:
         import subprocess
         import sys
 
+        probe = (
+            "import sys, secure_string_cipher; "
+            "print('secure_string_cipher.cli' in sys.modules)"
+        )
         result = subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                "import sys, secure_string_cipher; "
-                "print('secure_string_cipher.cli' in sys.modules)",
-            ],
+            [sys.executable, "-c", probe],
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
Closes #98.

## The problem

V2 had no stability tier at all:

- `secure_string_cipher.__all__` — 50 entries, every one v1
- `hasattr(secure_string_cipher, "v2")` — `False`
- `docs/API.md` — documented v2 usage anyway, and told readers to `from secure_string_cipher.v2.key_identity import compute_fingerprint`, a private third-level module

So the documentation was directing people at internals while the surface itself made no promise. That is worth settling *before* freezing an API, not after.

## Decision: public and semver-covered

Per your answer on the issue. Two levels:

| Level | Contents |
|---|---|
| `secure_string_cipher.v2.__all__` | the primitives — encrypt/decrypt, the three credential types, managed-key identity and keyfiles, `V2Header`, `V2VaultService`, and `app` |
| `secure_string_cipher.v2.app.__all__` | the layer above — key resolution, credential requirements, lifecycle policy; no prompting, no exiting |

`v2.__all__` goes from 10 names to 18, adding exactly what the documented examples need: `compute_fingerprint`, `load_keyfile`/`save_keyfile`, `KeyFileData`, `KeyStatus`/`KeyStorageMode`, `GrantType`. Anything below that — `v2.envelope`, `v2.vault_service` — stays internal, and the docstring says that needing something from there is a sign this surface is missing something, rather than an invitation.

**Not flattened into the root.** The root namespace is v1's API; two container formats in one namespace would leave a reader unable to tell which `encrypt_file` they were looking at. `from secure_string_cipher import v2` is the documented form and now works.

## Deprecations, and the ones I declined

`colorize`, `ProgressBar`, `main` → removal in 3.0.0, `DeprecationWarning` on access, still functional.

`main` is the one that matters: the export is `cli:main` (the interactive menu) while the installed `ssc` command is `cli_args:main`. Two different functions, one name — a genuine trap. They stay in `__all__` until the major bump, since removing them now would break `from secure_string_cipher import *` in a *minor* release; the warning is the signal, the removal is 3.0.0's.

Serving them lazily via PEP 562 `__getattr__` has a useful side effect: **importing the package no longer loads the interactive CLI module**, which it did solely to satisfy `main`. Asserted in a subprocess, since by the time any test runs in-process something else has usually imported `cli`.

**Declined**, from the audit's own list: `add_timing_jitter`, `PersistentRateLimiter`, `get_global_limiter`, `AuditLogger`, `get_audit_logger`. Each is usable on its own terms by a program embedding this library — a caller running its own passphrase attempts has the same reason to rate-limit them as the CLI does. Being used by the CLI does not make something a CLI internal, and deprecating a useful export to tidy the surface would cost users more than it buys. The reasoning is written into `docs/API.md` so the next reader does not re-litigate it.

## One test changed, and it got stricter

`test_api_index_covers_every_package_root_export` scanned the entire "Public API at a glance" section for backticked identifiers, so prose *about* the API — a deprecation note naming `DeprecationWarning` — counted as a documented export and failed the build. It now reads the table rows only, which is what it always meant. **Verified it still fails** when an export is dropped from the table.

## Verification

- 1693 tests pass (10 in the rewritten `test_v2_package.py`); `ruff` / `ruff format` / `mypy src` / `tools/check_sensitive_output.py` clean.
- Every name in both `__all__` lists is asserted to actually resolve — a declared-but-missing export is a broken promise, not a typo.
- The new README example was executed, not just written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
