### PR TITLE
docs: the v2.app stability tier is no longer undecided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@
   interactive input and never exits; it raises typed errors under a common
   `V2AppError` base. Obtaining a password stays with the caller, since where
   a password comes from is an interface concern. `cli_args.py` is now an
-  adapter over it with identical behaviour. Its stability tier is still to
-  be decided — the module is importable but not yet re-exported.
+  adapter over it with identical behaviour. It is public, semver-covered API
+  (see the `secure_string_cipher.v2` entry above), reachable as
+  `secure_string_cipher.v2.app`.
 
 ### Fixed
 


### PR DESCRIPTION
One-line correction. The `v2.app` entry in the unreleased CHANGELOG section still read:

> Its stability tier is still to be decided — the module is importable but not yet re-exported.

Both halves stopped being true in the *same* unreleased section: #122 declares `secure_string_cipher.v2` and `v2.app` public and semver-covered, and re-exports the subpackage at the root. A reader working down the section would have hit a contradiction between two entries a few paragraphs apart.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)