### PR TITLE
fix(core): never leave "Decryption failed: " dangling at the colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,16 @@
 
 ### Fixed
 
+- **A decryption failure could report "Decryption failed: " with nothing
+  after the colon.** A GCM tag failure raises
+  `cryptography.exceptions.InvalidTag()`, whose `str()` is empty; tampering
+  with a byte of ciphertext (as opposed to supplying the wrong password,
+  which fails key-commitment verification first, with a real message) hits
+  this path. `decrypt_text`/`decrypt_bytes` and `decrypt_file` now fall back
+  to a fixed phrase — "authentication failed — wrong password or corrupted
+  data" — whenever the underlying exception has nothing to add, rather than
+  leaving the message dangling at the colon.
+
 - **`.ssckey` files are now read in binary mode.** `load_keyfile` opened the
   descriptor without `O_BINARY`, so on Windows the C runtime collapsed CRLF
   to LF and truncated at a control-Z before the parser saw the bytes —

--- a/src/secure_string_cipher/core.py
+++ b/src/secure_string_cipher/core.py
@@ -537,6 +537,24 @@ class FileMetadata:
 # =============================================================================
 
 
+def _decryption_failure_message(error: Exception) -> str:
+    """Build a "Decryption failed" message that is never left dangling.
+
+    Most decrypt-time exceptions have a useful `str()`, but a GCM tag
+    failure raises `cryptography.exceptions.InvalidTag()`, whose `str()` is
+    empty -- producing "Decryption failed: " with nothing after the colon.
+    Falls back to a fixed phrase whenever the underlying exception has
+    nothing to add, without inventing detail the exception didn't provide
+    and without leaking the exception's type name.
+    """
+    detail = str(error)
+    if detail:
+        return f"Decryption failed: {detail}"
+    return (
+        "Decryption failed: authentication failed -- wrong password or corrupted data"
+    )
+
+
 def _encrypt_data(data: bytes, passphrase: str) -> bytes:
     """
     Encrypt data using AES-256-GCM with Argon2id and key commitment.
@@ -633,7 +651,7 @@ def _decrypt_data(encrypted: bytes, passphrase: str) -> bytes:
     except CryptoError:
         raise
     except Exception as e:
-        raise CryptoError(f"Decryption failed: {e}") from e
+        raise CryptoError(_decryption_failure_message(e)) from e
 
 
 def encrypt_text(text: str, passphrase: str) -> str:
@@ -1033,7 +1051,7 @@ def decrypt_file(
     except CryptoError:
         raise
     except Exception as e:
-        raise CryptoError(f"Decryption failed: {e}") from e
+        raise CryptoError(_decryption_failure_message(e)) from e
 
 
 # =============================================================================

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -219,6 +219,34 @@ class TestTextEncryption:
         with pytest.raises(CryptoError):
             decrypt_text(encrypted, TEST_PASSWORDS["NO_SYMBOLS"])
 
+    def test_wrong_password_message_names_key_commitment(self):
+        """A wrong password fails the key-commitment check specifically
+        (same ciphertext, different derived key), which has always had a
+        real message. Pinned here as the contrasting case to the tampered-
+        ciphertext test below, which historically did not."""
+        encrypted = encrypt_text("Hello, World!", TEST_PASSWORDS["VALID"])
+        with pytest.raises(CryptoError, match="Key commitment verification failed"):
+            decrypt_text(encrypted, TEST_PASSWORDS["NO_SYMBOLS"])
+
+    def test_tampered_ciphertext_message_is_never_left_dangling(self):
+        """A single flipped byte in the ciphertext/tag passes key-commitment
+        (the derived key is still correct) and fails GCM tag verification
+        instead, raising `cryptography.exceptions.InvalidTag`, whose
+        `str()` is empty. Before the fix, this produced the bare, malformed
+        message "Decryption failed: " with nothing after the colon."""
+        encrypted = encrypt_text("Hello, World!", TEST_PASSWORDS["VALID"])
+        raw = bytearray(base64.b64decode(encrypted))
+        raw[-1] ^= 0xFF  # last byte of the GCM tag
+        tampered = base64.b64encode(bytes(raw)).decode()
+
+        with pytest.raises(CryptoError) as exc_info:
+            decrypt_text(tampered, TEST_PASSWORDS["VALID"])
+        message = str(exc_info.value)
+        assert message.startswith("Decryption failed:")
+        assert not message.endswith(":")
+        assert not message.endswith(": ")
+        assert "wrong password or corrupted data" in message
+
     def test_corrupted_data(self):
         """Test handling of corrupted encrypted data."""
         with pytest.raises(CryptoError) as exc_info:
@@ -958,6 +986,38 @@ class TestErrorHandling:
         with contextlib.suppress(OSError):
             os.unlink(enc_path)
             os.unlink(dec_path)
+
+    def test_tampered_ciphertext_message_is_never_left_dangling(self, temp_file):
+        """File-decryption counterpart to the text test of the same name:
+        a flipped trailing byte fails the GCM tag (empty `str()` on the
+        underlying `InvalidTag`) rather than key commitment, and the
+        resulting CryptoError message must not be left dangling at the
+        colon."""
+        with open(temp_file, "wb") as f:
+            f.write(b"Secret data")
+
+        enc_path = temp_file + ".enc"
+        dec_path = temp_file + ".dec"
+        encrypt_file(temp_file, enc_path, TEST_PASSWORDS["VALID"])
+
+        with open(enc_path, "r+b") as f:
+            f.seek(-1, os.SEEK_END)
+            last_byte = f.read(1)
+            f.seek(-1, os.SEEK_END)
+            f.write(bytes([last_byte[0] ^ 0xFF]))
+
+        try:
+            with pytest.raises(CryptoError) as exc_info:
+                decrypt_file(enc_path, dec_path, TEST_PASSWORDS["VALID"])
+            message = str(exc_info.value)
+            assert message.startswith("Decryption failed:")
+            assert not message.endswith(":")
+            assert not message.endswith(": ")
+            assert "wrong password or corrupted data" in message
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(enc_path)
+                os.unlink(dec_path)
 
     def test_corrupted_metadata(self, temp_file):
         """Test handling of corrupted metadata in file."""


### PR DESCRIPTION
Closes #114.

## The bug

`cryptography.exceptions.InvalidTag()` has an empty `str()`. `decrypt_text`/`decrypt_bytes` and `decrypt_file` both built their failure message as `f"Decryption failed: {e}"`, so a tampered ciphertext byte produced the bare, malformed:

```
Decryption failed: 
```

## Why only *some* failures hit this

Confirmed empirically before fixing that a wrong password and a tampered ciphertext are genuinely distinct paths:

- **Wrong password** — fails key-commitment verification first (same ciphertext, different derived key), which has always had a real message: `"Key commitment verification failed - wrong password or tampered data"`.
- **Tampered ciphertext/tag byte** — correct key, failed AEAD tag verification, raises the empty-`str()` `InvalidTag`. Only this path was broken.

```python
>>> tampered[-1] ^= 0xFF  # a GCM-tag byte
>>> decrypt_text(tampered, correct_password)
CryptoError: Decryption failed: 
```

## The fix

`_decryption_failure_message(error)`: uses the exception's text when it has one, falls back to a fixed phrase — `"authentication failed — wrong password or corrupted data"` — when it doesn't. No invented detail, no leaked exception type name.

## Verification

- New test for both `decrypt_text` and `decrypt_file`: flips the last byte of a real ciphertext (part of the GCM tag), asserts the message never ends in `":"` or `": "`.
- A companion test pins the wrong-password case (key-commitment message) as a contrast, so the two failure modes stay distinguishable in the suite.
- **Falsified**: reverting to the old f-string fails both new tests with the exact string `'Decryption failed: '`. Restored before committing.
- 1700 tests pass; `ruff`/`ruff format`/`mypy`/`tools/check_sensitive_output.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)